### PR TITLE
Updates for Version 2.1

### DIFF
--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -209,8 +209,11 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Thumb}">
                         <Grid x:Name="Grid">
-                            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto" Fill="Transparent" />
-                            <Border x:Name="ScrollBarRectangle" CornerRadius="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto"  Background="{TemplateBinding Background}" />
+                            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto"
+                                       Height="Auto" Fill="Transparent" />
+                            <Border x:Name="ScrollBarRectangle" CornerRadius="5" HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Stretch" Width="Auto" Height="Auto"
+                                    Background="{TemplateBinding Background}" />
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="Tag" Value="Horizontal">
@@ -234,13 +237,16 @@
                         <Grid x:Name="GridRoot" Width="8" Background="{TemplateBinding Background}">
                             <Track x:Name="PART_Track" IsDirectionReversed="true" Focusable="false">
                                 <Track.Thumb>
-                                    <Thumb x:Name="ScrollBarThumb" Background="{TemplateBinding Foreground}" Style="{StaticResource ScrollThumbs}" />
+                                    <Thumb x:Name="ScrollBarThumb" Background="{TemplateBinding Foreground}"
+                                           Style="{StaticResource ScrollThumbs}" />
                                 </Track.Thumb>
                                 <Track.IncreaseRepeatButton>
-                                    <RepeatButton x:Name="PageUp" Command="ScrollBar.PageDownCommand" Opacity="0" Focusable="false" />
+                                    <RepeatButton x:Name="PageUp" Command="ScrollBar.PageDownCommand" Opacity="0"
+                                                  Focusable="false" />
                                 </Track.IncreaseRepeatButton>
                                 <Track.DecreaseRepeatButton>
-                                    <RepeatButton x:Name="PageDown" Command="ScrollBar.PageUpCommand" Opacity="0" Focusable="false" />
+                                    <RepeatButton x:Name="PageDown" Command="ScrollBar.PageUpCommand" Opacity="0"
+                                                  Focusable="false" />
                                 </Track.DecreaseRepeatButton>
                             </Track>
                         </Grid>

--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -190,7 +190,7 @@
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="WindowBorderThickness" Value="0" />
             <Setter Property="WindowStartupLocation" Value="Center" />
-            <Setter Property="Margin" Value="0,0,0,50" />
+            <Setter Property="Margin" Value="0,0,0,250" />
         </Style>
 
         <Style x:Key="PreviewImage" TargetType="Image">

--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -9,6 +9,10 @@
                 Value="../Resources/TF2Build.ttf #TF2 Build" />
         <Setter x:Key="Tf2Secondary" Property="TextElement.FontFamily"
                 Value="../Resources/TF2Secondary.ttf #TF2 Secondary" />
+        <Setter x:Key="Tf2Icons" Property="TextElement.FontFamily"
+                Value="../Resources/TF2Icons.ttf #TF2 Icons" />
+        <Setter x:Key="Tf2Crosshairs" Property="TextElement.FontFamily"
+                Value="../Resources/TF2Crosshairs.ttf #TF2Crosshairs" />
 
         <Style TargetType="Label">
             <Setter Property="HorizontalAlignment" Value="Left" />
@@ -20,6 +24,15 @@
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="VerticalAlignment" Value="Top" />
             <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="18" />
+        </Style>
+
+        <Style x:Key="ComboBoxLabel" TargetType="Label">
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Width" Value="150" />
+            <Setter Property="FontSize" Value="16" />
         </Style>
 
         <Style TargetType="ComboBox">
@@ -27,13 +40,22 @@
             <Setter Property="VerticalAlignment" Value="Top" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
             <Setter Property="SelectedValuePath" Value="Content" />
-            <Setter Property="Width" Value="200px" />
+            <Setter Property="Width" Value="150" />
         </Style>
 
         <Style TargetType="GroupBox">
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Margin" Value="5" />
+        </Style>
+
+        <Style x:Key="ColorPickerLabel" TargetType="Label">
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="VerticalAlignment" Value="Top" />
             <Setter Property="Foreground" Value="White" />
+            <Setter Property="Width" Value="125" />
+            <Setter Property="FontSize" Value="16" />
         </Style>
 
         <Style TargetType="x2:ColorPicker">
@@ -42,7 +64,15 @@
             <Setter Property="ColorMode" Value="ColorCanvas" />
             <Setter Property="ShowRecentColors" Value="True" />
             <Setter Property="Foreground" Value="Black" />
-            <Setter Property="Width" Value="100px" />
+            <Setter Property="Width" Value="125" />
+        </Style>
+
+        <Style x:Key="IntegerUpDownLabel" TargetType="Label">
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Width" Value="100" />
+            <Setter Property="FontSize" Value="16" />
         </Style>
 
         <Style TargetType="x2:IntegerUpDown">
@@ -51,8 +81,16 @@
             <Setter Property="TextAlignment" Value="Center" />
             <Setter Property="FormatString" Value="N0" />
             <Setter Property="Increment" Value="1" />
-            <Setter Property="Width" Value="200px" />
+            <Setter Property="Width" Value="100" />
             <Setter Property="AllowTextInput" Value="False" />
+        </Style>
+
+        <Style x:Key="CrosshairLabel" TargetType="Label">
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Width" Value="125" />
+            <Setter Property="FontSize" Value="16" />
         </Style>
 
         <Style x:Key="Crosshair" TargetType="ComboBoxItem">
@@ -124,6 +162,114 @@
             <Setter Property="FontSize" Value="33px" />
             <Setter Property="Foreground" Value="#FFFFFF" />
             <Setter Property="BorderThickness" Value="0" />
+        </Style>
+
+        <Style x:Key="PreviewButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontFamily" Value="../Resources/TF2Icons.ttf #TF2Icons" />
+            <Setter Property="Margin" Value="10,0,0,0" />
+            <Setter Property="Height" Value="20" />
+            <Setter Property="Content" Value="?" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="VerticalContentAlignment" Value="Top" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Foreground" Value="Black" />
+                </Trigger>
+                <Trigger Property="IsMouseOver" Value="False">
+                    <Setter Property="Foreground" Value="White" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="PreviewPanel" TargetType="x2:ChildWindow">
+            <Setter Property="WindowBackground" Value="Black" />
+            <Setter Property="CaptionForeground" Value="White" />
+            <Setter Property="Background" Value="Black" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="WindowBorderThickness" Value="0" />
+            <Setter Property="WindowStartupLocation" Value="Center" />
+            <Setter Property="Margin" Value="0,0,0,50" />
+        </Style>
+
+        <Style x:Key="PreviewImage" TargetType="Image">
+            <Setter Property="Height" Value="600" />
+            <Setter Property="Width" Value="600" />
+        </Style>
+
+        <Style x:Key="PageTitle" TargetType="Label">
+            <Setter Property="FontSize" Value="35" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Margin" Value="10,10,0,0" />
+        </Style>
+
+        <Style x:Key="ScrollThumbs" TargetType="{x:Type Thumb}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Thumb}">
+                        <Grid x:Name="Grid">
+                            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto" Fill="Transparent" />
+                            <Border x:Name="ScrollBarRectangle" CornerRadius="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto"  Background="{TemplateBinding Background}" />
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="Tag" Value="Horizontal">
+                                <Setter TargetName="ScrollBarRectangle" Property="Width" Value="Auto" />
+                                <Setter TargetName="ScrollBarRectangle" Property="Height" Value="7" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style TargetType="{x:Type ScrollBar}">
+            <Setter Property="Margin" Value="-5,0,0,0" />
+            <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
+            <Setter Property="Foreground" Value="#FF8C8C8C" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Width" Value="8" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ScrollBar}">
+                        <Grid x:Name="GridRoot" Width="8" Background="{TemplateBinding Background}">
+                            <Track x:Name="PART_Track" IsDirectionReversed="true" Focusable="false">
+                                <Track.Thumb>
+                                    <Thumb x:Name="ScrollBarThumb" Background="{TemplateBinding Foreground}" Style="{StaticResource ScrollThumbs}" />
+                                </Track.Thumb>
+                                <Track.IncreaseRepeatButton>
+                                    <RepeatButton x:Name="PageUp" Command="ScrollBar.PageDownCommand" Opacity="0" Focusable="false" />
+                                </Track.IncreaseRepeatButton>
+                                <Track.DecreaseRepeatButton>
+                                    <RepeatButton x:Name="PageDown" Command="ScrollBar.PageUpCommand" Opacity="0" Focusable="false" />
+                                </Track.DecreaseRepeatButton>
+                            </Track>
+                        </Grid>
+
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsEnabled" Value="false">
+                                <Setter TargetName="ScrollBarThumb" Property="Visibility" Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="Orientation" Value="Horizontal">
+                                <Setter TargetName="GridRoot" Property="LayoutTransform">
+                                    <Setter.Value>
+                                        <RotateTransform Angle="-90" />
+                                    </Setter.Value>
+                                </Setter>
+                                <Setter TargetName="PART_Track" Property="LayoutTransform">
+                                    <Setter.Value>
+                                        <RotateTransform Angle="-90" />
+                                    </Setter.Value>
+                                </Setter>
+                                <Setter Property="Width" Value="Auto" />
+                                <Setter Property="Height" Value="8" />
+                                <Setter TargetName="ScrollBarThumb" Property="Tag" Value="Horizontal" />
+                                <Setter TargetName="PageDown" Property="Command" Value="ScrollBar.PageLeftCommand" />
+                                <Setter TargetName="PageUp" Property="Command" Value="ScrollBar.PageRightCommand" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
     </Application.Resources>
 </Application>

--- a/src/TF2HUD.Editor/Classes/HUD.cs
+++ b/src/TF2HUD.Editor/Classes/HUD.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using TF2HUD.Editor.JSON;
@@ -101,6 +102,21 @@ namespace TF2HUD.Editor.Classes
             Grid.SetRow(title, 0);
             container.Children.Add(title);
 
+            // Create the preview modal
+            var preview = new ChildWindow
+            {
+                Style = (Style) Application.Current.Resources["PreviewPanel"]
+            };
+            preview.MouseDoubleClick += (_, _) => { preview.Close(); };
+
+            var image = new Image
+            {
+                Style = (Style) Application.Current.Resources["PreviewImage"]
+            };
+            preview.Content = image;
+
+            container.Children.Add(preview);
+
             // NOTE: ColumnDefinition and RowDefinition only exist on Grid, not Panel, so we are forced to use dynamic for each section.
             dynamic sectionsContainer;
 
@@ -186,6 +202,22 @@ namespace TF2HUD.Editor.Classes
                             sectionContent.Children.Add(checkBoxInput);
                             controlItem.Control = checkBoxInput;
 
+                            // Create a preview button if the control has a preview image.
+                            if (!string.IsNullOrWhiteSpace(controlItem.Preview))
+                            {
+                                var previewBtn = new Button
+                                {
+                                    Style = (Style) Application.Current.Resources["PreviewButton"]
+                                };
+                                previewBtn.Click += (_, _) =>
+                                {
+                                    preview.Caption = !string.IsNullOrWhiteSpace(tooltip) ? tooltip : id;
+                                    image.Source = new BitmapImage(new Uri(controlItem.Preview));
+                                    preview.Show();
+                                };
+                                sectionContent.Children.Add(previewBtn);
+                            }
+
                             break;
 
                         case "color":
@@ -238,6 +270,24 @@ namespace TF2HUD.Editor.Classes
                             colorContainer.Children.Add(colorInput);
                             sectionContent.Children.Add(colorContainer);
                             controlItem.Control = colorInput;
+
+                            // Create a preview button if the control has a preview image.
+                            if (!string.IsNullOrWhiteSpace(controlItem.Preview))
+                            {
+                                var previewBtn = new Button
+                                {
+                                    Style = (Style) Application.Current.Resources["PreviewButton"]
+                                };
+                                previewBtn.Click += (_, _) =>
+                                {
+                                    preview.Caption = !string.IsNullOrWhiteSpace(tooltip)
+                                        ? tooltip
+                                        : id;
+                                    image.Source = new BitmapImage(new Uri(controlItem.Preview));
+                                    preview.Show();
+                                };
+                                sectionContent.Children.Add(previewBtn);
+                            }
 
                             break;
 
@@ -296,6 +346,24 @@ namespace TF2HUD.Editor.Classes
                             sectionContent.Children.Add(comboBoxContainer);
                             controlItem.Control = comboBoxInput;
 
+                            // Create a preview button if the control has a preview image.
+                            if (!string.IsNullOrWhiteSpace(controlItem.Preview))
+                            {
+                                var previewBtn = new Button
+                                {
+                                    Style = (Style) Application.Current.Resources["PreviewButton"]
+                                };
+                                previewBtn.Click += (_, _) =>
+                                {
+                                    preview.Caption = !string.IsNullOrWhiteSpace(tooltip)
+                                        ? tooltip
+                                        : id;
+                                    image.Source = new BitmapImage(new Uri(controlItem.Preview));
+                                    preview.Show();
+                                };
+                                sectionContent.Children.Add(previewBtn);
+                            }
+
                             break;
 
                         case "number":
@@ -334,6 +402,24 @@ namespace TF2HUD.Editor.Classes
                             integerContainer.Children.Add(integerInput);
                             sectionContent.Children.Add(integerContainer);
                             controlItem.Control = integerInput;
+
+                            // Create a preview button if the control has a preview image.
+                            if (!string.IsNullOrWhiteSpace(controlItem.Preview))
+                            {
+                                var previewBtn = new Button
+                                {
+                                    Style = (Style) Application.Current.Resources["PreviewButton"]
+                                };
+                                previewBtn.Click += (_, _) =>
+                                {
+                                    preview.Caption = !string.IsNullOrWhiteSpace(tooltip)
+                                        ? tooltip
+                                        : id;
+                                    image.Source = new BitmapImage(new Uri(controlItem.Preview));
+                                    preview.Show();
+                                };
+                                sectionContent.Children.Add(previewBtn);
+                            }
 
                             break;
 
@@ -385,6 +471,24 @@ namespace TF2HUD.Editor.Classes
                             xhairContainer.Children.Add(xhairInput);
                             sectionContent.Children.Add(xhairContainer);
                             controlItem.Control = xhairInput;
+
+                            // Create a preview button if the control has a preview image.
+                            if (!string.IsNullOrWhiteSpace(controlItem.Preview))
+                            {
+                                var previewBtn = new Button
+                                {
+                                    Style = (Style) Application.Current.Resources["PreviewButton"]
+                                };
+                                previewBtn.Click += (_, _) =>
+                                {
+                                    preview.Caption = !string.IsNullOrWhiteSpace(tooltip)
+                                        ? tooltip
+                                        : id;
+                                    image.Source = new BitmapImage(new Uri(controlItem.Preview));
+                                    preview.Show();
+                                };
+                                sectionContent.Children.Add(previewBtn);
+                            }
 
                             break;
 

--- a/src/TF2HUD.Editor/Classes/HUD.cs
+++ b/src/TF2HUD.Editor/Classes/HUD.cs
@@ -92,9 +92,8 @@ namespace TF2HUD.Editor.Classes
             // Define the title of the HUD displayed at the top of the page.
             var title = new Label
             {
-                Content = Name,
-                FontSize = 35,
-                Margin = new Thickness(10, 10, 0, 0)
+                Style = (Style) Application.Current.Resources["PageTitle"],
+                Content = Name
             };
             Grid.SetRow(title, 0);
             container.Children.Add(title);
@@ -139,10 +138,7 @@ namespace TF2HUD.Editor.Classes
             {
                 var sectionContainer = new GroupBox
                 {
-                    Header = section,
-                    Margin = new Thickness(5),
-                    HorizontalAlignment = HorizontalAlignment.Stretch,
-                    VerticalAlignment = VerticalAlignment.Stretch
+                    Header = section
                 };
 
                 Panel sectionContent = layout != null ? new WrapPanel() : new StackPanel();
@@ -153,7 +149,8 @@ namespace TF2HUD.Editor.Classes
                 {
                     var id = controlItem.Name;
                     var label = controlItem.Label;
-                    Settings.AddSetting(controlItem.Name, controlItem);
+                    var tooltip = controlItem.Tooltip;
+                    Settings.AddSetting(id, controlItem);
 
                     switch (controlItem.Type.ToLowerInvariant())
                     {
@@ -163,12 +160,10 @@ namespace TF2HUD.Editor.Classes
                             {
                                 Name = id,
                                 Content = label,
-                                Margin = new Thickness(10, lastTop + 10, 0, 0),
-                                IsChecked = Settings.GetSetting<bool>(controlItem.Name)
+                                Margin = new Thickness(10, lastTop + 10, 30, 0),
+                                IsChecked = Settings.GetSetting<bool>(id),
+                                ToolTip = tooltip
                             };
-
-                            // Add Tooltip text, if available.
-                            checkBoxInput.ToolTip = controlItem.Tooltip;
 
                             // Add Events.
                             checkBoxInput.Checked += (sender, _) =>
@@ -199,17 +194,13 @@ namespace TF2HUD.Editor.Classes
                             var colorLabel = new Label
                             {
                                 Content = label,
-                                Width = 125,
-                                FontSize = 16
+                                Style = (Style) Application.Current.Resources["ColorPickerLabel"]
                             };
                             var colorInput = new ColorPicker
                             {
                                 Name = id,
-                                Width = 125
+                                ToolTip = tooltip
                             };
-
-                            // Add Tooltip text, if available.
-                            colorInput.ToolTip = controlItem.Tooltip;
 
                             // Attempt to bind the color from the settings.
                             try
@@ -257,17 +248,13 @@ namespace TF2HUD.Editor.Classes
                             var comboBoxLabel = new Label
                             {
                                 Content = label,
-                                Width = 150,
-                                FontSize = 16
+                                Style = (Style) Application.Current.Resources["ComboBoxLabel"]
                             };
                             var comboBoxInput = new ComboBox
                             {
                                 Name = id,
-                                Width = 150
+                                ToolTip = tooltip
                             };
-
-                            // Add Tooltip text, if available.
-                            comboBoxInput.ToolTip = controlItem.Tooltip;
 
                             // Add items to the ComboBox.
                             foreach (var option in controlItem.Options)
@@ -281,7 +268,7 @@ namespace TF2HUD.Editor.Classes
                             }
 
                             // Set the selected value depending on the what's retrieved from the setting file.
-                            var comboValue = Settings.GetSetting<string>(controlItem.Name);
+                            var comboValue = Settings.GetSetting<string>(id);
                             if (!Regex.IsMatch(comboValue, "\\D"))
                                 comboBoxInput.SelectedIndex = int.Parse(comboValue);
                             else
@@ -312,21 +299,17 @@ namespace TF2HUD.Editor.Classes
                             var integerLabel = new Label
                             {
                                 Content = label,
-                                Width = 100,
-                                FontSize = 16
+                                Style = (Style) Application.Current.Resources["IntegerUpDownLabel"]
                             };
                             var integerInput = new IntegerUpDown
                             {
                                 Name = id,
-                                Width = 100,
-                                Value = Settings.GetSetting<int>(controlItem.Name),
+                                Value = Settings.GetSetting<int>(id),
                                 Minimum = controlItem.Minimum,
                                 Maximum = controlItem.Maximum,
-                                Increment = controlItem.Increment
+                                Increment = controlItem.Increment,
+                                ToolTip = tooltip
                             };
-
-                            // Add Tooltip text, if available.
-                            integerInput.ToolTip = controlItem.Tooltip;
 
                             // Add Events.
                             integerInput.ValueChanged += (sender, _) =>
@@ -352,16 +335,13 @@ namespace TF2HUD.Editor.Classes
                             var xhairLabel = new Label
                             {
                                 Content = label,
-                                Width = 125,
-                                FontSize = 16
+                                Style = (Style) Application.Current.Resources["CrosshairLabel"]
                             };
                             var xhairInput = new ComboBox
                             {
-                                Name = id
+                                Name = id,
+                                ToolTip = tooltip
                             };
-
-                            // Add Tooltip text, if available.
-                            xhairInput.ToolTip = controlItem.Tooltip;
 
                             // Add items to the ComboBox.
                             foreach (var item in Utilities.CrosshairStyles.Select(option => new ComboBoxItem
@@ -375,7 +355,7 @@ namespace TF2HUD.Editor.Classes
                             }
 
                             // Set the selected value depending on the what's retrieved from the setting file.
-                            var xhairValue = Settings.GetSetting<string>(controlItem.Name);
+                            var xhairValue = Settings.GetSetting<string>(id);
                             if (!Regex.IsMatch(xhairValue, "\\D"))
                                 xhairInput.SelectedIndex = int.Parse(xhairValue);
                             else
@@ -394,28 +374,28 @@ namespace TF2HUD.Editor.Classes
                             sectionContent.Children.Add(xhairContainer);
                             controlItem.Control = xhairInput;
                             break;
-                            
+
                         case "custombackground":
                             // Create the Control.
-                            var bgInput = new Button()
+                            var bgInput = new Button
                             {
                                 Name = id,
                                 Content = label,
                                 Height = 32,
                                 Margin = new Thickness(10, lastTop + 10, 0, 0),
-                                Padding = new Thickness(5, 2, 5, 0)
+                                Padding = new Thickness(5, 2, 5, 0),
+                                ToolTip = tooltip
                             };
 
-                            // Add Tooltip text, if available.
-                            bgInput.ToolTip = controlItem.Tooltip;
-
                             // Add Events.
-                            bgInput.Click += (sender, _) =>
+                            bgInput.Click += (_, _) =>
                             {
-                                var result = MainWindow.ShowMessageBox(MessageBoxImage.Warning, Resources.info_custom_background, MessageBoxButton.YesNo);
-                                if (result != MessageBoxResult.Yes) return;
-                                var imagePath = new BackgroundManager($"{MainWindow.HudPath}\\{Name}\\").ApplyCustomBackground();
-                                Settings.SetSetting(bgInput?.Name, imagePath);
+                                if (MainWindow.ShowMessageBox(MessageBoxImage.Warning,
+                                        Resources.ask_custom_background, MessageBoxButton.YesNo) !=
+                                    MessageBoxResult.Yes) return;
+                                var imagePath = new BackgroundManager($"{MainWindow.HudPath}\\{Name}\\")
+                                    .ApplyCustomBackground();
+                                Settings.SetSetting(bgInput.Name, imagePath);
                             };
 
                             // Add to Page.
@@ -472,6 +452,13 @@ namespace TF2HUD.Editor.Classes
                     }
                 }
 
+                var scrollViewer = new ScrollViewer
+                {
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    Content = sectionContainer.Content,
+                    Background = new SolidColorBrush(Colors.Transparent)
+                };
+                sectionContainer.Content = scrollViewer;
                 sectionsContainer.Children.Add(sectionContainer);
                 groupBoxIndex++;
             }
@@ -774,7 +761,7 @@ namespace TF2HUD.Editor.Classes
                     if (string.Equals(userSetting.Type, "ComboBox", StringComparison.CurrentCultureIgnoreCase))
                         enable = !string.Equals(userSetting.Value, "0");
 
-                    EvaluateSpecial(Special, hudSetting, userSetting, enable);
+                    EvaluateSpecial(Special, userSetting, enable);
                 }
 
                 if (Files == null) return;
@@ -1146,21 +1133,18 @@ namespace TF2HUD.Editor.Classes
 
         private (JObject, string) GetControlInfo(Controls hudSetting, Setting userSetting)
         {
-            if (string.Equals(hudSetting.Type, "ComboBox", StringComparison.CurrentCultureIgnoreCase))
-            {
-                // Determine files using the files of the selected item's label or value
-                // Could cause issues if label and value are both numbers but numbered differently
-                var selected =
-                    hudSetting.Options.First(x => x.Label == userSetting.Value || x.Value == userSetting.Value);
-                return (selected.Files, selected.Special);
-            }
-
-            return (hudSetting.Files, hudSetting.Special);
+            if (!string.Equals(hudSetting.Type, "ComboBox", StringComparison.CurrentCultureIgnoreCase))
+                return (hudSetting.Files, hudSetting.Special);
+            // Determine files using the files of the selected item's label or value
+            // Could cause issues if label and value are both numbers but numbered differently
+            var selected =
+                hudSetting.Options.First(x => x.Label == userSetting.Value || x.Value == userSetting.Value);
+            return (selected.Files, selected.Special);
         }
 
         #region CUSTOM SETTINGS
 
-        private void EvaluateSpecial(string Special, Controls hudSetting, Setting userSetting, bool enable)
+        private void EvaluateSpecial(string Special, Setting userSetting, bool enable)
         {
             // Check for special conditions, namely if we should enable stock backgrounds.
 
@@ -1201,7 +1185,9 @@ namespace TF2HUD.Editor.Classes
             {
                 // Copy the config file required for this feature
                 if (!enable) return true;
-                File.Copy(Directory.GetCurrentDirectory() + "\\Resources\\mastercomfig-transparent-viewmodels-addon.vpk", MainWindow.HudPath + "\\mastercomfig-transparent-viewmodels-addon.vpk", true);
+                File.Copy(
+                    Directory.GetCurrentDirectory() + "\\Resources\\mastercomfig-transparent-viewmodels-addon.vpk",
+                    MainWindow.HudPath + "\\mastercomfig-transparent-viewmodels-addon.vpk", true);
                 return true;
             }
             catch (Exception e)

--- a/src/TF2HUD.Editor/Classes/HUDBackground.cs
+++ b/src/TF2HUD.Editor/Classes/HUDBackground.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Windows;
+using System.Windows.Forms;
+using TF2HUD.Editor.Properties;
 
 namespace TF2HUD.Editor.Classes
 {
@@ -105,11 +107,23 @@ namespace TF2HUD.Editor.Classes
         {
             try
             {
-                customImagePath = (string.IsNullOrWhiteSpace(customImagePath)) ? GetFilePathFromUser() : customImagePath;
+                // Check that the directory for the game backgrounds exists.
+                var bgPath = $"{HUDFolderPath}\\materials\\console";
+                if (!Directory.Exists(bgPath))
+                    Directory.CreateDirectory(bgPath);
+
+                // Get the image path from the user if it is not already set.
+                customImagePath = string.IsNullOrWhiteSpace(customImagePath) ? GetFilePathFromUser() : customImagePath;
+
+                // Initialize the VTF converter then convert the image file.
                 var converter = new VTF(MainWindow.HudPath.Replace("\\tf\\custom\\", string.Empty));
-                var output = $"{HUDFolderPath}\\materials\\console\\background_upward.vtf";
+                var output = $"{bgPath}\\background_upward.vtf";
                 converter.Convert(customImagePath, output);
+
+                // Copy the generated background file and chapterbackgrounds.txt to apply the changes.
                 File.Copy(output, output.Replace("background_upward", "background_upward_widescreen"), true);
+                File.Copy(Directory.GetCurrentDirectory() + "\\Resources\\chapterbackgrounds.txt",
+                    $"{HUDFolderPath}\\scripts\\chapterbackgrounds.txt", true);
                 return customImagePath;
             }
             catch (Exception ex)
@@ -123,11 +137,16 @@ namespace TF2HUD.Editor.Classes
         ///     Get the custom background image path from the user.
         /// </summary>
         /// <returns>String path to the new background image file.</returns>
-        public string GetFilePathFromUser()
+        public static string GetFilePathFromUser()
         {
-            using var browser = new System.Windows.Forms.OpenFileDialog();
+            using var browser = new OpenFileDialog
+            {
+                Filter = "Image files (*.jpg, *.jpeg, *.jpe, *.jfif, *.png) | *.jpg; *.jpeg; *.jpe; *.jfif; *.png",
+                Title = Resources.ask_image_browser,
+                Multiselect = false
+            };
             browser.ShowDialog();
-            return (string.IsNullOrWhiteSpace(browser.FileName)) ? null : browser.FileName;
+            return string.IsNullOrWhiteSpace(browser.FileName) ? null : browser.FileName;
         }
     }
 }

--- a/src/TF2HUD.Editor/Classes/Json.cs
+++ b/src/TF2HUD.Editor/Classes/Json.cs
@@ -59,7 +59,7 @@ namespace TF2HUD.Editor.Classes
                 // Get the local schema names and file sizes.
                 List<Tuple<string, int>> localFiles = new();
                 foreach (var file in new DirectoryInfo("JSON").GetFiles().Where(x => x.FullName.EndsWith(".json")))
-                    localFiles.Add(new Tuple<string, int>(file.Name.Replace(".json", string.Empty), (int)file.Length));
+                    localFiles.Add(new Tuple<string, int>(file.Name.Replace(".json", string.Empty), (int) file.Length));
                 if (localFiles.Count <= 0) return false;
 
                 // Setup the WebClient for download remote files.
@@ -73,7 +73,8 @@ namespace TF2HUD.Editor.Classes
 
                 // Get the remote schema names and file sizes.
                 List<Tuple<string, int>> remoteFiles = new();
-                foreach (var file in JsonConvert.DeserializeObject<List<GitJson>>(remoteList).Where(x => x.Name.EndsWith(".json")))
+                foreach (var file in JsonConvert.DeserializeObject<List<GitJson>>(remoteList)
+                    .Where(x => x.Name.EndsWith(".json")))
                     remoteFiles.Add(new Tuple<string, int>(file.Name.Replace(".json", string.Empty), file.Size));
                 if (remoteFiles.Count <= 0) return false;
 

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -94,7 +94,7 @@ namespace TF2HUD.Editor
                 Logger.Info("Opening a folder browser to get the tf/custom directory from the user.");
                 using (var browser = new FolderBrowserDialog
                 {
-                    Description = Properties.Resources.info_folder_browser,
+                    Description = Properties.Resources.ask_folder_browser,
                     UseDescriptionForTitle = true,
                     ShowNewFolderButton = true
                 })
@@ -221,6 +221,7 @@ namespace TF2HUD.Editor
                 BtnUninstall.IsEnabled = false;
                 BtnSave.IsEnabled = false;
                 BtnReset.IsEnabled = false;
+                BtnSwitch.IsEnabled = false;
                 BtnGitHub.IsEnabled = false;
                 BtnHuds.IsEnabled = false;
                 BtnDiscord.IsEnabled = false;
@@ -237,6 +238,7 @@ namespace TF2HUD.Editor
                 BtnUninstall.IsEnabled = isInstalled;
                 BtnSave.IsEnabled = isInstalled;
                 BtnReset.IsEnabled = isInstalled;
+                BtnSwitch.IsEnabled = true;
                 LblStatus.Content = $"{HudSelection} is {(!isInstalled ? "not " : "")}installed...";
             }
             else
@@ -247,6 +249,7 @@ namespace TF2HUD.Editor
                 BtnUninstall.IsEnabled = false;
                 BtnSave.IsEnabled = false;
                 BtnReset.IsEnabled = false;
+                BtnSwitch.IsEnabled = true;
                 LblStatus.Content = "Directory is not set...";
             }
         }
@@ -440,6 +443,14 @@ namespace TF2HUD.Editor
         /// </summary>
         private void BtnSave_OnClick(object sender, RoutedEventArgs e)
         {
+            var hudObject = Json.GetHUDByName(Settings.Default.hud_selected);
+            if (Process.GetProcessesByName("hl2").Any() && hudObject.DirtyControls.Count > 0)
+            {
+                var message = hudObject.DirtyControls.Aggregate(Properties.Resources.info_game_restart,
+                    (current, control) => current + $"\n - {control}");
+                if (ShowMessageBox(MessageBoxImage.Question, message) != MessageBoxResult.OK) return;
+            }
+
             Logger.Info("Applying HUD Settings...");
             var worker = new BackgroundWorker();
             worker.DoWork += (_, _) =>
@@ -450,6 +461,7 @@ namespace TF2HUD.Editor
                     var selection = Json.GetHUDByName(Settings.Default.hud_selected);
                     selection.Settings.SaveSettings();
                     selection.ApplyCustomizations();
+                    selection.DirtyControls.Clear();
                 });
             };
             worker.RunWorkerAsync();
@@ -462,11 +474,16 @@ namespace TF2HUD.Editor
         /// </summary>
         private void BtnReset_OnClick(object sender, RoutedEventArgs e)
         {
+            // Ask the user if they want to reset before doing so.
+            if (ShowMessageBox(MessageBoxImage.Question, Properties.Resources.ask_reset_options,
+                MessageBoxButton.YesNo) != MessageBoxResult.Yes) return;
+
             Logger.Info("Resetting HUD Settings...");
             var selection = Json.GetHUDByName(Settings.Default.hud_selected);
             selection.Reset();
             selection.Settings.SaveSettings();
             selection.ApplyCustomizations();
+            selection.DirtyControls.Clear();
             LblStatus.Content = "Settings Reset at " + DateTime.Now;
             Logger.Info("Resetting HUD Settings...Done!");
         }
@@ -504,7 +521,9 @@ namespace TF2HUD.Editor
         /// </summary>
         private void BtnRefresh_OnClick(object sender, RoutedEventArgs e)
         {
-            LblStatus.Content = Json.Update() ? Properties.Resources.info_schema_update : Properties.Resources.info_schema_nothing;
+            LblStatus.Content = Json.Update()
+                ? Properties.Resources.info_schema_update
+                : Properties.Resources.info_schema_nothing;
         }
 
         private void BtnSteam_OnClick(object sender, RoutedEventArgs e)
@@ -551,6 +570,5 @@ namespace TF2HUD.Editor
         }
 
         #endregion
-
     }
 }

--- a/src/TF2HUD.Editor/Resources/chapterbackgrounds.txt
+++ b/src/TF2HUD.Editor/Resources/chapterbackgrounds.txt
@@ -1,0 +1,15 @@
+"chapters"
+{
+	1	"background_upward"
+	2	"background_upward"
+	3	"background_upward"
+	4	"background_upward"
+}
+
+"BackgroundMaps"
+{
+	1	"background_upward"
+	2	"background_upward"
+	3	"background_upward"
+	4	"background_upward"
+}

--- a/src/TF2HUD.Editor/TF2HUD.Editor.csproj
+++ b/src/TF2HUD.Editor/TF2HUD.Editor.csproj
@@ -37,6 +37,7 @@
     <None Remove="JSON\zeeshud.json" />
     <None Remove="log4net.config" />
     <None Remove="Resources\banner.png" />
+    <None Remove="Resources\chapterbackgrounds.txt" />
     <None Remove="Resources\favicon.ico" />
     <None Remove="Resources\mastercomfig-transparent-viewmodels-addon.vpk" />
     <None Remove="Resources\TF2Build.ttf" />
@@ -76,6 +77,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Resources\banner.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\chapterbackgrounds.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Resources\mastercomfig-transparent-viewmodels-addon.vpk">


### PR DESCRIPTION
- Added a **Restart Required** notification when modifying certain controls while the game is running (#30)
- Added a notification for resetting customization options and selecting the custom backgrounds option.
- Added a scroll viewer to group boxes whose controls overflow (#39)
- Added an image modal for previewing a customization (#36)
- Fixed the **Switch HUDs** button staying enabled while on the main menu.
- Fixed the editor not verifying the output path for custom backgrounds.
- Fixed the file browser not being restricted to images when choosing a new background.
- Moved some control properties to App.xaml
- `chapterbackgrounds.txt` will now be copied when generating a custom VTF background.