### PR TITLE
clean: Create HudDirectory and Notifier classes to remove dependency on MainWindow

### DIFF
--- a/src/TF2HUD.Editor/Classes/HUD/HUD.cs
+++ b/src/TF2HUD.Editor/Classes/HUD/HUD.cs
@@ -23,7 +23,7 @@ namespace HUDEditor.Classes
         /// </summary>
         /// <param name="name">Name of the HUD object.</param>
         /// <param name="schema">Contents of the HUD's schema file.</param>
-        public HUD(string name, HudJson schema, bool uniq)
+        public HUD(string name, HudJson schema, bool uniq, Notifier notifier)
         {
             // Basic Schema Properties.
             Name = schema.Name ?? name;
@@ -45,7 +45,7 @@ namespace HUDEditor.Classes
             LayoutOptions = schema.Layout;
             DirtyControls = new List<string>();
             Unique = uniq;
-
+            _notifier = notifier;
             if (schema.Screenshots is null) return;
             var index = 0;
             foreach (var screenshot in schema.Screenshots)
@@ -352,6 +352,7 @@ namespace HUDEditor.Classes
         public List<string> DirtyControls;
         public List<object> Screenshots { get; set; } = new();
         public bool Unique;
+        private readonly Notifier _notifier;
 
         #endregion
     }

--- a/src/TF2HUD.Editor/Classes/HUD/HUDBackground.cs
+++ b/src/TF2HUD.Editor/Classes/HUD/HUDBackground.cs
@@ -19,15 +19,17 @@ namespace HUDEditor.Classes
     internal class HUDBackground
     {
         private readonly string HUDFolderPath;
+        private readonly Notifier _notifier;
         private string customImagePath;
         private string HUDImagePath;
         private bool useCustomBackground;
         private bool useHUDBackground;
         private bool useStockBackgrounds;
 
-        public HUDBackground(string hudPath)
+        public HUDBackground(string hudPath, Notifier notifier)
         {
             HUDFolderPath = hudPath;
+            _notifier = notifier;
         }
 
         public void SetStockBackgrounds(bool enable)
@@ -150,7 +152,7 @@ namespace HUDEditor.Classes
             }
             catch (Exception e)
             {
-                MainWindow.ShowMessageBox(MessageBoxImage.Error, e.Message);
+                _notifier.ShowMessageBox(MessageBoxImage.Error, e.Message);
             }
         }
     }

--- a/src/TF2HUD.Editor/Classes/HUD/HUDCustomizations.cs
+++ b/src/TF2HUD.Editor/Classes/HUD/HUDCustomizations.cs
@@ -24,7 +24,7 @@ namespace HUDEditor.Classes
                 // HUD Background Image.
                 // Set the HUD Background image path when applying, because it's possible
                 // the user did not have their tf/custom folder set up when this HUD constructor was called.
-                HudBackground = new HUDBackground($"{MainWindow.HudPath}\\{Name}\\");
+                HudBackground = new HUDBackground($"{MainWindow.HudPath}\\{Name}\\", _notifier);
 
                 var hudSettings = ControlOptions.Values;
                 // var hudSettings = JsonConvert.DeserializeObject<HudJson>(File.ReadAllText($"JSON//{Name}.json")).Controls.Values;
@@ -711,7 +711,7 @@ namespace HUDEditor.Classes
                     }
                     else
                     {
-                        MainWindow.ShowMessageBox(MessageBoxImage.Error, string.Format(Utilities.GetLocalizedString(Resources.error_unknown_extension), extension));
+                        _notifier.ShowMessageBox(MessageBoxImage.Error, string.Format(Utilities.GetLocalizedString(Resources.error_unknown_extension), extension));
                     }
                 }
             }
@@ -752,7 +752,7 @@ namespace HUDEditor.Classes
         /// <summary>
         ///     Copy configuration file for transparent viewmodels into the HUD's cfg folder.
         /// </summary>
-        public static bool CopyTransparentViewmodelAddon(bool enable = false)
+        public bool CopyTransparentViewmodelAddon(bool enable = false)
         {
             try
             {
@@ -767,7 +767,7 @@ namespace HUDEditor.Classes
             }
             catch (Exception e)
             {
-                MainWindow.ShowMessageBox(MessageBoxImage.Error, string.Format(Utilities.GetLocalizedString(Resources.error_transparent_vm), e.Message));
+                _notifier.ShowMessageBox(MessageBoxImage.Error, string.Format(Utilities.GetLocalizedString(Resources.error_transparent_vm), e.Message));
                 return false;
             }
         }

--- a/src/TF2HUD.Editor/Classes/HUD/HUDPage.cs
+++ b/src/TF2HUD.Editor/Classes/HUD/HUDPage.cs
@@ -616,7 +616,7 @@ namespace HUDEditor.Classes
                             // Add Events.
                             bgInput.Click += (_, _) =>
                             {
-                                MainWindow.ShowMessageBox(MessageBoxImage.Information, Resources.info_background_override);
+                                _notifier.ShowMessageBox(MessageBoxImage.Information, Resources.info_background_override);
                                 using (var browser = new OpenFileDialog())
                                 {
                                     browser.ShowDialog();

--- a/src/TF2HUD.Editor/Classes/HudDirectory.cs
+++ b/src/TF2HUD.Editor/Classes/HudDirectory.cs
@@ -1,0 +1,115 @@
+﻿using HUDEditor.Properties;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Forms;
+
+namespace HUDEditor.Classes
+{
+    public class HudDirectory
+    {
+        private readonly ILog _logger;
+        private readonly Notifier _notifier;
+
+        public HudDirectory(ILog logger, Notifier notifier)
+        {
+            _logger = logger;
+            _notifier = notifier;
+        }
+
+        /// <summary>
+        ///     Setup the tf/custom directory, if it's not already set.
+        /// </summary>
+        /// <param name="userInitiated">Flags the process as being user initiated, skip right to the folder browser.</param>
+        public void Setup(string currentHudPath, bool userInitiated = false)
+        {
+            if (!userInitiated && AlreadySetup(currentHudPath))
+            {
+                return;
+            }
+
+            SetupWithFolderBrowser();
+
+            if (NotSetup(Settings.Default.hud_directory))
+            {
+                QuitApplication();
+            }
+        }
+        
+        private bool AlreadySetup(string currentHudPath)
+        {
+            return Utilities.CheckUserPath(currentHudPath) || Utilities.SearchRegistry();
+        }
+
+        private void SetupWithFolderBrowser()
+        {
+            _logger.Info("tf/custom directory is not set. Asking the user...");
+
+            using var browser = new FolderBrowserDialog
+            {
+                Description = Properties.Resources.info_path_browser,
+                UseDescriptionForTitle = true,
+                ShowNewFolderButton = true
+            };
+            var selectedDirectory = GetSelectedDirectory(browser);
+            if (selectedDirectory != null)
+            {
+                SaveDirectory(selectedDirectory);
+            }
+        }
+
+        /// <summary>
+        /// Loop until the user provides a valid tf/custom directory, unless they cancel out.
+        /// </summary>
+        /// <param name="browser"></param>
+        /// <returns>The selected directory.</returns>
+        private string GetSelectedDirectory(FolderBrowserDialog browser)
+        {
+            while (!IsValidDirectory(browser.SelectedPath))
+            {
+                if (browser.ShowDialog() != DialogResult.OK)
+                {
+                    return null;
+                }
+
+                if (!IsValidDirectory(browser.SelectedPath))
+                {
+                    _notifier.ShowMessageBox(MessageBoxImage.Error, Properties.Resources.info_path_invalid);
+                    return null;
+                }
+
+                return browser.SelectedPath;
+            }
+
+            return null;
+        }
+
+        private static bool IsValidDirectory(string directory)
+        {
+            return directory?.EndsWith("tf\\custom") ?? false;
+        }
+
+        private void SaveDirectory(string selectedDirectory)
+        {
+            Settings.Default.hud_directory = selectedDirectory;
+            Settings.Default.Save();
+            _logger.Info($"tf/custom directory is set to: {Settings.Default.hud_directory}");
+        }
+
+        private static bool NotSetup(string currentHudPath)
+        {
+            return !Utilities.CheckUserPath(currentHudPath);
+        }
+
+        private void QuitApplication()
+        {
+            _logger.Info("tf/custom directory still not set. Exiting...");
+            _notifier.ShowMessageBox(MessageBoxImage.Warning, Utilities.GetLocalizedString(Properties.Resources.error_app_directory));
+            System.Windows.Application.Current.Shutdown();
+        }
+    }
+}

--- a/src/TF2HUD.Editor/Classes/Notifier.cs
+++ b/src/TF2HUD.Editor/Classes/Notifier.cs
@@ -1,0 +1,42 @@
+﻿using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace HUDEditor.Classes
+{
+    public class Notifier
+    {
+        private readonly ILog _logger;
+
+        public Notifier(ILog logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Display a message box with a message to the user and log it.
+        /// </summary>
+        public MessageBoxResult ShowMessageBox(MessageBoxImage type, string message, MessageBoxButton buttons = MessageBoxButton.OK)
+        {
+            LogMessage(type, message);
+            return MessageBox.Show(message, string.Empty, buttons, type);
+        }
+
+        private void LogMessage(MessageBoxImage type, string message)
+        {
+            switch (type)
+            {
+                case MessageBoxImage.Error:
+                    _logger.Error(message);
+                    break;
+                case MessageBoxImage.Warning:
+                    _logger.Warn(message);
+                    break;
+            }
+        }
+    }
+}

--- a/src/TF2HUD.Editor/Classes/Utilities.cs
+++ b/src/TF2HUD.Editor/Classes/Utilities.cs
@@ -197,12 +197,10 @@ namespace HUDEditor.Classes
         /// <summary>
         ///     Check if Team Fortress 2 is currently running.
         /// </summary>
-        /// <returns>False if there's no active process named hl2, otherwise return true and a warning message.</returns>
-        public static bool CheckIsGameRunning()
+        /// <returns>False if there's no active process named hl2, otherwise true.</returns>
+        public static bool IsGameRunning()
         {
-            if (!Process.GetProcessesByName("hl2").Any()) return false;
-            MainWindow.ShowMessageBox(MessageBoxImage.Warning, GetLocalizedString(Resources.info_game_running));
-            return true;
+            return Process.GetProcessesByName("hl2").Any();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR pulls logic out of MainWindow and puts it into new classes: HudDirectory and Notifier. This will remove some dependencies on MainWindow for configuring the HUD directory and displaying MessageBoxes.

My reasoning for making these changes is twofold: increase maintainability and pave the way for testability.

While working on this, I noticed how hard it was to pull logic out since it relied so much on the MainWindow. Even something simple as displaying a MessageBox was difficult. From my experience, using dependency injection helps a ton when it comes to splitting out logic rather than calling a static class (such as MainWindow and Utilities). Also, some methods are doing more than two things (for example, checking the registry for the config path and saving it to settings if found). From my experience, it helps to keep each method small and focused, that way it can be easily unit tested. It would also reduce side effects and make the code easier to follow.

I would love to help split out more of the logic and set up dependency injection to aid maintainability. If we can remove dependencies on MainWindow and other static classes, we can start unit testing the logic that doesn't rely on Windows Forms since we can mock the dependencies. This would remove the need for most manual testing. I would also be willing to help set up the test project.

Let me know what you think! I'm open to suggestions.