### PR TITLE
Fix crashes related to social buttons

### DIFF
--- a/src/TF2HUD.Editor/Classes/Json.cs
+++ b/src/TF2HUD.Editor/Classes/Json.cs
@@ -30,8 +30,14 @@ namespace HUDEditor.Classes
         // HUDs to manage
         public HUD[] HUDList;
 
-        public Json()
+        private readonly MainWindowDelegate _selectedHudSet;
+        private readonly MainWindowDelegate _selectedHudCleared;
+
+        public Json(MainWindowDelegate selectedHudSet, MainWindowDelegate selectedHudCleared)
         {
+            _selectedHudSet = selectedHudSet;
+            _selectedHudCleared = selectedHudCleared;
+
             var hudList = new List<HUD>();
             foreach (var jsonFile in Directory.EnumerateFiles("JSON"))
             {
@@ -96,6 +102,10 @@ namespace HUDEditor.Classes
                 _highlightedHud = value;
                 OnPropertyChanged("HighlightedHUD");
                 OnPropertyChanged("HighlightedHUDInstalled");
+                if (_highlightedHud != null)
+                    _selectedHudSet();
+                else
+                    _selectedHudCleared();
             }
         }
 

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ using MessageBox = System.Windows.MessageBox;
 
 namespace HUDEditor
 {
+    public delegate void MainWindowDelegate();
     /// <summary>
     ///     Interaction logic for MainWindow.xaml
     /// </summary>
@@ -46,7 +47,9 @@ namespace HUDEditor
             Logger.Info("Initializing.");
 
             // Get the list of HUD JSONs.
-            Json = new Json();
+            MainWindowDelegate enableSocialButtons = EnableSocialButtons;
+            MainWindowDelegate disableSocialButtons = DisableSocialButtons;
+            Json = new Json(enableSocialButtons, disableSocialButtons);
             InitializeComponent();
             DataContext = this;
 
@@ -217,6 +220,30 @@ namespace HUDEditor
             }
 
             return MessageBox.Show(message, string.Empty, buttons, type);
+        }
+
+        private void DisableSocialButtons()
+        {
+            if (BtnGitHub != null)
+                BtnGitHub.IsEnabled = false;
+            if (BtnHuds != null)
+                BtnHuds.IsEnabled = false;
+            if (BtnDiscord != null)
+                BtnDiscord.IsEnabled = false;
+            if (BtnSteam != null)
+                BtnSteam.IsEnabled = false;
+        }
+
+        private void EnableSocialButtons()
+        {
+            if (BtnGitHub != null)
+                BtnGitHub.IsEnabled = true;
+            if (BtnHuds != null)
+                BtnHuds.IsEnabled = true;
+            if (BtnDiscord != null)
+                BtnDiscord.IsEnabled = true;
+            if (BtnSteam != null)
+                BtnSteam.IsEnabled = true;
         }
 
         /// <summary>

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -536,7 +536,7 @@ namespace HUDEditor
         /// </summary>
         private void BtnReportIssue_OnClick(object sender, RoutedEventArgs e)
         {
-            Utilities.OpenWebpage(Settings.Default.app_tracker);
+            Utilities.OpenWebpage(Settings.Default?.app_tracker);
         }
 
         /// <summary>
@@ -544,7 +544,7 @@ namespace HUDEditor
         /// </summary>
         private void BtnDocumentation_OnClick(object sender, RoutedEventArgs e)
         {
-            Utilities.OpenWebpage(Settings.Default.app_docs);
+            Utilities.OpenWebpage(Settings.Default?.app_docs);
         }
 
         /// <summary>
@@ -572,22 +572,22 @@ namespace HUDEditor
 
         private void BtnGitHub_OnClick(object sender, RoutedEventArgs e)
         {
-            Utilities.OpenWebpage(Json.HighlightedHUD.GitHubUrl);
+            Utilities.OpenWebpage(Json?.HighlightedHUD?.GitHubUrl);
         }
 
         private void BtnHuds_OnClick(object sender, RoutedEventArgs e)
         {
-            Utilities.OpenWebpage(Json.HighlightedHUD.HudsTfUrl);
+            Utilities.OpenWebpage(Json?.HighlightedHUD?.HudsTfUrl);
         }
 
         private void BtnDiscord_OnClick(object sender, RoutedEventArgs e)
         {
-            Utilities.OpenWebpage(Json.HighlightedHUD.DiscordUrl);
+            Utilities.OpenWebpage(Json?.HighlightedHUD?.DiscordUrl);
         }
 
         private void BtnSteam_OnClick(object sender, RoutedEventArgs e)
         {
-            Utilities.OpenWebpage(Json.HighlightedHUD.SteamUrl);
+            Utilities.OpenWebpage(Json?.HighlightedHUD?.SteamUrl);
         }
 
         /// <summary>


### PR DESCRIPTION
#88 

This PR will disable the social buttons when the highlighted HUD is null and enable them when a highlighted HUD is set. It also adds some null checks when accessing the social links before attempting to open the web page.