### PR TITLE
delete HudSelection as a directory

### DIFF
--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -402,7 +402,7 @@ namespace HUDEditor
                 // Remove the HUD from the tf/custom directory.
                 Logger.Info($"Start uninstalling {HudSelection}.");
                 Logger.Info($"Removing {HudSelection} from: {HudPath}");
-                Directory.Delete(HudPath + $"\\{HudSelection}", true);
+                Directory.Delete(HudPath + $"\\{HudSelection}\\", true);
                 Json.OnPropertyChanged("HighlightedHUD");
                 Json.OnPropertyChanged("HighlightedHUDInstalled");
             }


### PR DESCRIPTION
Had the same problem as described in Issue #92, but after adding a `\` to the end of the `{HudSelection}`, it fixed the issue.