### PR TITLE
HOTFIX

### DIFF
--- a/src/TF2HUD.Editor/JSON/kbnhud.json
+++ b/src/TF2HUD.Editor/JSON/kbnhud.json
@@ -437,7 +437,7 @@
         "Files": {
           "^customizations/#hitmarkers/hitmarkers_hudlayout.res": {
             "HitMarker": {
-              "enabled": {
+              "visible": {
                 "true": "1",
                 "false": "0"
               }


### PR DESCRIPTION
Hitmarkers weren't being properly disabled, editor was set to change the "enabled" value in the files but this caused a colorless (black) ghost of the hitmarker to still appear. Updated HUD with a hotfix and this is to match, hitmarker enable/disable checkbox now changes the "visible" value, which works. Also merged edits made to KBNHud schema by CriticalFlaw.