### PR TITLE
Add Brazilian Portuguese localization

### DIFF
--- a/src/TF2HUD.Editor/Properties/Resources.pt-BR.resx
+++ b/src/TF2HUD.Editor/Properties/Resources.pt-BR.resx
@@ -151,7 +151,7 @@
     <value>As seguintes alterações requerem que o jogo seja reiniciado:</value>
   </data>
   <data name="info_game_running" xml:space="preserve">
-    <value>Não foi possível continuar porque o Team Fortress 2 está sendo executado. Feche o jogo e tente novamente.</value>
+    <value>Não foi possível prosseguir porque o Team Fortress 2 está sendo executado. Feche o jogo e tente novamente.</value>
   </data>
   <data name="info_hud_backup" xml:space="preserve">
     <value>Uma instalação existente da {0} foi encontrada. Para evitar conflitos, um backup foi criado.</value>

--- a/src/TF2HUD.Editor/Properties/Resources.pt-BR.resx
+++ b/src/TF2HUD.Editor/Properties/Resources.pt-BR.resx
@@ -1,0 +1,261 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="error_app_directory" xml:space="preserve">
+    <value>O diretório de tf/custom deve ser definido para usar este editor.</value>
+  </data>
+  <data name="error_hud_install" xml:space="preserve">
+    <value>Ocorreu um erro ao instalar {0}.</value>
+  </data>
+  <data name="error_hud_missing" xml:space="preserve">
+    <value>Não foi possível encontrar a HUD {0}!</value>
+  </data>
+  <data name="error_hud_uninstall" xml:space="preserve">
+    <value>Ocorreu um erro ao desinstalar {0}.</value>
+  </data>
+  <data name="error_transparent_vm" xml:space="preserve">
+    <value>Ocorreu um erro ao alternar os Viewmodels Transparentes.</value>
+  </data>
+  <data name="error_unknown_extension" xml:space="preserve">
+    <value>Não foi possível reconhecer a extensão de arquivo '{0}'.</value>
+  </data>
+  <data name="header_restart_required" xml:space="preserve">
+    <value>Reinicialização necessária.</value>
+  </data>
+  <data name="header_update_none" xml:space="preserve">
+    <value>Nenhuma atualização encontrada.</value>
+  </data>
+  <data name="info_add_hud" xml:space="preserve">
+    <value>Tem certeza de que deseja adicionar uma pasta à lista de HUDs compartilhadas? Isto adicionará a pasta localmente, mas não enviará a HUD ao banco de dados online do TF2HUD.Editor.</value>
+  </data>
+  <data name="info_background_override" xml:space="preserve">
+    <value>Definir um novo plano de fundo substituirá o atual. Use a opção "Reinstalar" para reverter ao plano de fundo padrão.</value>
+  </data>
+  <data name="info_game_restart" xml:space="preserve">
+    <value>As seguintes alterações requerem que o jogo seja reiniciado:</value>
+  </data>
+  <data name="info_game_running" xml:space="preserve">
+    <value>Não foi possível continuar porque o Team Fortress 2 está sendo executado. Feche o jogo e tente novamente.</value>
+  </data>
+  <data name="info_hud_backup" xml:space="preserve">
+    <value>Uma instalação existente da {0} foi encontrada. Para evitar conflitos, um backup foi criado.</value>
+  </data>
+  <data name="info_hud_reset" xml:space="preserve">
+    <value>Tem certeza de que deseja redefinir todas as personalizações para os seus padrões?</value>
+  </data>
+  <data name="info_hud_update" xml:space="preserve">
+    <value>Há uma nova atualização disponível para o esquema de HUDs. Você gostaria de reiniciar agora para aplicar as novas alterações?</value>
+  </data>
+  <data name="info_hud_update_none" xml:space="preserve">
+    <value>Você tem a última versão do esquema de HUDs. Verifique novamente mais tarde.</value>
+  </data>
+  <data name="info_path_browser" xml:space="preserve">
+    <value>Selecione o diretório de tf/custom. Se um diretório inválido for especificado, várias opções estarão indisponíveis.</value>
+  </data>
+  <data name="info_path_invalid" xml:space="preserve">
+    <value>O caminho que você escolheu não termina em tf/custom. Tente novamente.</value>
+  </data>
+  <data name="info_unsupported_hud_found" xml:space="preserve">
+    <value>Uma HUD não suportada foi encontrada em tf/custom. Deseja deletá-la para prosseguir com a instalação?</value>
+  </data>
+  <data name="status_applied" xml:space="preserve">
+    <value>As personalizações da {0} foram aplicadas em {1}.</value>
+  </data>
+  <data name="status_installed" xml:space="preserve">
+    <value>{0} está instalada!</value>
+  </data>
+  <data name="status_installed_not" xml:space="preserve">
+    <value>{0} não está instalada!</value>
+  </data>
+  <data name="status_installed_now" xml:space="preserve">
+    <value>A instalação da {0} foi finalizada em {1}.</value>
+  </data>
+  <data name="status_pathNotSet" xml:space="preserve">
+    <value>O diretório de tf/custom não está definido!</value>
+  </data>
+  <data name="status_reset" xml:space="preserve">
+    <value>As personalizações da {0} foram redefinidas em {1}.</value>
+  </data>
+  <data name="tooltip_addhud" xml:space="preserve">
+    <value>Adicionar nova HUD.</value>
+  </data>
+  <data name="tooltip_docs" xml:space="preserve">
+    <value>Ler a documentação.</value>
+  </data>
+  <data name="tooltip_path" xml:space="preserve">
+    <value>Alterar diretório de tf/custom.</value>
+  </data>
+  <data name="tooltip_refresh" xml:space="preserve">
+    <value>Verificar novas atualizações para o esquema de HUDs.</value>
+  </data>
+  <data name="tooltip_report" xml:space="preserve">
+    <value>Relatar um problema.</value>
+  </data>
+  <data name="ui_apply" xml:space="preserve">
+    <value>Aplicar alterações</value>
+  </data>
+  <data name="ui_author" xml:space="preserve">
+    <value>Criada por: {0}</value>
+  </data>
+  <data name="ui_back" xml:space="preserve">
+    <value>Voltar</value>
+  </data>
+  <data name="ui_browse" xml:space="preserve">
+    <value>Navegar</value>
+  </data>
+  <data name="ui_check_updates" xml:space="preserve">
+    <value>Verificar atualizações automaticamente.</value>
+  </data>
+  <data name="ui_clear" xml:space="preserve">
+    <value>Limpar</value>
+  </data>
+  <data name="ui_customize" xml:space="preserve">
+    <value>Personalizar</value>
+  </data>
+  <data name="ui_directory" xml:space="preserve">
+    <value>Definir caminho para tf/custom</value>
+  </data>
+  <data name="ui_install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="ui_options" xml:space="preserve">
+    <value>Opções</value>
+  </data>
+  <data name="ui_refresh" xml:space="preserve">
+    <value>Verificar atualizações</value>
+  </data>
+  <data name="ui_reinstall" xml:space="preserve">
+    <value>Reinstalar</value>
+  </data>
+  <data name="ui_reset" xml:space="preserve">
+    <value>Restaurar padrões</value>
+  </data>
+  <data name="ui_search" xml:space="preserve">
+    <value>Buscar:</value>
+  </data>
+  <data name="ui_select" xml:space="preserve">
+    <value>Selecione uma HUD</value>
+  </data>
+  <data name="ui_switch" xml:space="preserve">
+    <value>Trocar HUDs</value>
+  </data>
+  <data name="ui_uninstall" xml:space="preserve">
+    <value>Desinstalar</value>
+  </data>
+</root>


### PR DESCRIPTION
When the Brazilian Portuguese language gets added to the language list, abbreviate it as "B-Portuguese", "Portuguese-BR", "BR-Portuguese" or anything that highlights that it is Brazilian. Abbreviating just as "Portuguese" is not an option, as there is also the Portuguese from Portugal.