### PR TITLE
Added support for multiple download sources

### DIFF
--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -134,7 +134,7 @@
             <Setter Property="Foreground" Value="#EBE2CA" />
             <Setter Property="Background" Value="#776B5F" />
             <Setter Property="Margin" Value="5" />
-            <Setter Property="Width" Value="160" />
+            <Setter Property="Width" Value="130" />
             <Setter Property="Height" Value="40" />
             <Setter Property="Template">
                 <Setter.Value>

--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -130,11 +130,11 @@
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="VerticalAlignment" Value="Top" />
             <Setter Property="FontFamily" Value="../Resources/TF2Build.ttf #TF2 Build" />
-            <Setter Property="FontSize" Value="14px" />
+            <Setter Property="FontSize" Value="16px" />
             <Setter Property="Foreground" Value="#EBE2CA" />
             <Setter Property="Background" Value="#776B5F" />
             <Setter Property="Margin" Value="5" />
-            <Setter Property="Width" Value="130" />
+            <Setter Property="Width" Value="235" />
             <Setter Property="Height" Value="40" />
             <Setter Property="Template">
                 <Setter.Value>
@@ -159,7 +159,7 @@
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="VerticalAlignment" Value="Top" />
             <Setter Property="FontFamily" Value="../Resources/TF2Icons.ttf #TF2Icons" />
-            <Setter Property="Width" Value="50px" />
+            <Setter Property="Width" Value="72px" />
             <Setter Property="FontSize" Value="33px" />
             <Setter Property="Foreground" Value="#FFFFFF" />
             <Setter Property="Background" Value="#776B5F" />

--- a/src/TF2HUD.Editor/Classes/HUD/HUD.cs
+++ b/src/TF2HUD.Editor/Classes/HUD/HUD.cs
@@ -36,7 +36,7 @@ namespace HUDEditor.Classes
             Author = schema.Author;
             CustomizationsFolder = schema.CustomizationsFolder ?? string.Empty;
             EnabledFolder = schema.EnabledFolder ?? string.Empty;
-            UpdateUrl = schema.Links.Update ?? string.Empty;
+            Download = schema.Links.Download;
             GitHubUrl = schema.Links.GitHub ?? string.Empty;
             HudsTfUrl = schema.Links.HudsTf ?? string.Empty;
             SteamUrl = schema.Links.Steam ?? string.Empty;
@@ -65,9 +65,9 @@ namespace HUDEditor.Classes
         /// <summary>
         ///     Call to download the HUD if a URL has been provided.
         /// </summary>
-        public async Task Update()
+        public async Task Update(string path)
         {
-            await Utilities.DownloadFile(UpdateUrl, "temp.zip");
+            await Utilities.DownloadFile(path, "temp.zip");
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace HUDEditor.Classes
         public string Author { get; set; }
         public string CustomizationsFolder { get; set; }
         public string EnabledFolder { get; set; }
-        public string UpdateUrl { get; set; }
+        public Download[] Download;
         public string GitHubUrl { get; set; }
         public string HudsTfUrl { get; set; }
         public string SteamUrl { get; set; }

--- a/src/TF2HUD.Editor/Classes/Json.cs
+++ b/src/TF2HUD.Editor/Classes/Json.cs
@@ -241,11 +241,11 @@ namespace HUDEditor.Classes
                 }).Result,
                 Links = new Links
                 {
-                    Update = Task.Run(() =>
+                    Download = Task.Run(() =>
                     {
                         var zipPath = $"{hudDetailsFolder}\\{hudName}.zip";
                         ZipFile.CreateFromDirectory(folderPath, zipPath, CompressionLevel.Fastest, true);
-                        return $"file://{zipPath}";
+                        return new[] { new Download() { Source = "GitHub", Link = $"file://{zipPath}" } };
                     }).Result
                 }
             };

--- a/src/TF2HUD.Editor/Classes/Json.cs
+++ b/src/TF2HUD.Editor/Classes/Json.cs
@@ -70,7 +70,7 @@ namespace HUDEditor.Classes
                     Layout = sharedProperties.Layout,
                     Links = new Links
                     {
-                        Update = $"file://{sharedHud}\\{hudName}.zip"
+                        Download = new[] { new Download() { Source = "GitHub", Link = $"file://{sharedHud}\\{hudName}.zip" } }
                     },
                     Controls = sharedProperties.Controls
                 }, false));

--- a/src/TF2HUD.Editor/JSON/Schema/schema.json
+++ b/src/TF2HUD.Editor/JSON/Schema/schema.json
@@ -21,9 +21,24 @@
     "Links": {
       "type": "object",
       "properties": {
-        "Update": {
-          "type": "string",
-          "pattern": "^https?:\/\/.*$"
+        "Download": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Source": {
+                "type": "string"
+              },
+              "Link": {
+                "type": "string",
+                "pattern": "^https?:\/\/.*$"
+              }
+            },
+            "required": [
+              "Source",
+              "Link"
+            ]
+          }
         },
         "GitHub": {
           "type": "string",
@@ -43,7 +58,7 @@
         }
       },
       "required": [
-        "Update"
+        "Download"
       ]
     },
     "Controls": {

--- a/src/TF2HUD.Editor/JSON/Schema/schema_shared.json
+++ b/src/TF2HUD.Editor/JSON/Schema/schema_shared.json
@@ -23,9 +23,24 @@
             "type": "object",
             "items": {
               "properties": {
-                "Update": {
-                  "type": "string",
-                  "pattern": "^https?:\/\/.*$"
+                "Download": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Source": {
+                        "type": "string"
+                      },
+                      "Link": {
+                        "type": "string",
+                        "pattern": "^https?:\/\/.*$"
+                      }
+                    },
+                    "required": [
+                      "Source",
+                      "Link"
+                    ]
+                  }
                 },
                 "GitHub": {
                   "type": "string",

--- a/src/TF2HUD.Editor/JSON/Shared/shared.json
+++ b/src/TF2HUD.Editor/JSON/Shared/shared.json
@@ -5,9 +5,15 @@
     "Author": "PeachesTV",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/3151_1601749117_3bbd70f3/8b9e290bc3bd43fa3a78b4b2d8cacaed/PeachMountainBlurHUDSTF.png",
     "Links": {
-      "Update": "https://github.com/PapaPeach/PeachHUD/archive/refs/heads/master.zip",
+      "Update": "https://github.com/PapaPeach/PeachHUD/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/PapaPeach/PeachHUD",
-      "HudsTF": "https://huds.tf/site/s-PeachHUD"
+      "HudsTF": "https://huds.tf/site/s-PeachHUD",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/PapaPeach/PeachHUD/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://i.imgur.com/4c3nhSV.jpeg",
@@ -21,9 +27,15 @@
     "Author": "omnibombulator",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/3420_1610890758_652bc68e/ec8c1fb5d4553dbb8e8dc0d8df64299c/collyhud-logo.jpg",
     "Links": {
-      "Update": "https://github.com/omnibombulator/collyhud/archive/refs/heads/master.zip",
+      "Update": "https://github.com/omnibombulator/collyhud/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/omnibombulator/collyhud",
-      "HudsTF": "https://huds.tf/site/s-collyhud"
+      "HudsTF": "https://huds.tf/site/s-collyhud",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/omnibombulator/collyhud/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/3422_1610890758_9b89263a/b0b281edb5d4442e6ae731a302f33b3c/main-menu.jpg",
@@ -38,9 +50,15 @@
     "Author": "Hypnotize",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/244_1575132372_f2b65a9e/69ce71dfb6eb377f69f18d9f5cf505de/tZsHgRf.png",
     "Links": {
-      "Update": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip",
+      "Update": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/Hypnootize/m0rehud",
-      "HudsTF": "https://huds.tf/site/s-m0re-Hud"
+      "HudsTF": "https://huds.tf/site/s-m0re-Hud",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/245_1629748124_7320d20f/d75ca2baeb429f8e56e399b709186133/FCPZxX1.jpg",
@@ -55,10 +73,16 @@
     "Author": "sevin",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/287_1517885994_ad8b68b6/94d1eb4fd3ad5ab90f998dde1870be18/0W4Jl83.jpg",
     "Links": {
-      "Update": "https://github.com/Sevin7/7HUD/archive/refs/heads/master.zip",
+      "Update": "https://github.com/Sevin7/7HUD/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/Sevin7/7HUD",
       "HudsTF": "https://huds.tf/site/s-7HUD",
-      "Steam": "https://steamcommunity.com/groups/7HUD"
+      "Steam": "https://steamcommunity.com/groups/7HUD",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/Sevin7/7HUD/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/288_1599103773_83aafed7/e8125e88da73575361be0c1171bcec54/WJlr2wB.jpg",
@@ -73,10 +97,16 @@
     "Author": "flatline",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/183_1589906946_b0997177/668f0762c806292d1f6250d5ca442498/ompredux.png",
     "Links": {
-      "Update": "https://github.com/flatlinee/omphudedit/archive/refs/heads/master.zip",
+      "Update": "https://github.com/flatlinee/omphudedit/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/flatlinee/omphudedit",
       "Steam": "https://steamcommunity.com/groups/omphudredux",
-      "HudsTF": "https://huds.tf/site/s-omphud-redux"
+      "HudsTF": "https://huds.tf/site/s-omphud-redux",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/flatlinee/omphudedit/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/184_1589731402_3a5f187e/f4dd154950058ebc088b2d5562dcf3b5/hl2_AEv6jrVfuL.jpg",
@@ -91,9 +121,15 @@
     "Author": "flatline",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/2889_1589906478_5ca05758/2534c1f999d376f7e774285adfcecec2/cliphudlogo.png",
     "Links": {
-      "Update": "https://github.com/flatlinee/cliphud/archive/refs/heads/master.zip",
+      "Update": "https://github.com/flatlinee/cliphud/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/flatlinee/cliphud",
-      "HudsTF": "https://huds.tf/site/s-cliphud--2175"
+      "HudsTF": "https://huds.tf/site/s-cliphud--2175",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/flatlinee/cliphud/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/2890_1589735040_d4ab575b/5fd0e7267145bdf50b4eadaff58a11f8/hl2_eG1FxavHdl.jpg",
@@ -108,10 +144,16 @@
     "Author": "flatline",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/41_1589907522_90a9a980/af69128b77fd75cf580b25b3acdef47f/flathudlogooo2.png",
     "Links": {
-      "Update": "https://github.com/flatlinee/flathud/archive/refs/heads/master.zip",
+      "Update": "https://github.com/flatlinee/flathud/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/flatlinee/flathud",
       "Steam": "https://steamcommunity.com/groups/flathud",
-      "HudsTF": "https://huds.tf/site/s-flathud"
+      "HudsTF": "https://huds.tf/site/s-flathud",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/flatlinee/flathud/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/42_1589729867_7fb9a0eb/778ba698510b64b4cef5ed2fb4f596eb/hl2_f2tMtjL5c1.png",
@@ -126,9 +168,15 @@
     "Author": "Broesel, Hypnotize",
     "Thumbnail": "https://huds.tf/site/xthreads_attach.php/2113_1592073837_94a362ba/0424be29ee076d1d76c25cc785a4bb43/zaguUvP.png",
     "Links": {
-      "Update": "https://github.com/Hypnootize/Broesel-Hud/archive/refs/heads/master.zip",
+      "Update": "https://github.com/Hypnootize/Broesel-Hud/archive/refs/heads/master.zip", // TODO: Remove
       "GitHub": "https://github.com/Hypnootize/Broesel-Hud",
-      "HudsTF": "https://huds.tf/site/s-Broesel-Hud"
+      "HudsTF": "https://huds.tf/site/s-Broesel-Hud",
+      "Download": [
+        {
+          "Source": "GitHub",
+          "Link": "https://github.com/Hypnootize/Broesel-Hud/archive/refs/heads/master.zip"
+        }
+      ]
     },
     "Screenshots": [
       "https://huds.tf/site/xthreads_attach.php/2115_1592073837_b79fd8e7/dc1828c5a652b2af2ec869ba268a7084/BKNQ0er.jpg",

--- a/src/TF2HUD.Editor/JSON/ahud.json
+++ b/src/TF2HUD.Editor/JSON/ahud.json
@@ -4,9 +4,15 @@
   "Description": "A custom HUD for Team Fortress 2. Inspired from various HUDs, including, but not limited to, rayshud, yahud, and omphud.",
   "Thumbnail": "https://huds.tf/site/xthreads_attach.php/35_1605074316_8287ffb1/b0305f84d3a470e4a31d0d4863fcc94b/ahud.png",
   "Links": {
-    "Update": "https://github.com/n0kk/ahud/archive/refs/heads/master.zip",
+    "Update": "https://github.com/n0kk/ahud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/n0kk/ahud",
-    "HudsTF": "https://huds.tf/site/s-ahud"
+    "HudsTF": "https://huds.tf/site/s-ahud",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/n0kk/ahud/archive/refs/heads/master.zip"
+      }
+    ]
   },
   "Screenshots": [
     "https://huds.tf/site/xthreads_attach.php/2612_1605074316_9ec56435/2899c0edb205aaaf22432bd7ea3d3944/Kx70I3P.jpg",
@@ -33,7 +39,7 @@
         "Label": "Chat To Top Left",
         "Type": "Checkbox",
         "ToolTip": "Move the in game chat to the top left of the screen",
-        "Value": false,
+        "Value": "false",
         "Restart": false,
         "Files": {
           "resource/ui/basechat.res": {

--- a/src/TF2HUD.Editor/JSON/budhud.json
+++ b/src/TF2HUD.Editor/JSON/budhud.json
@@ -17,11 +17,17 @@
     "4 7 7 7"
   ],
   "Links": {
-    "Update": "https://github.com/rbjaxter/budhud/archive/master.zip",
+    "Update": "https://github.com/rbjaxter/budhud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/rbjaxter/budhud",
     "HudsTF": "https://huds.tf/site/s-budhud",
     "Steam": "https://steamcommunity.com/groups/budhud",
-    "Discord": "https://discord.com/invite/TkxNKU2"
+    "Discord": "https://discord.com/invite/TkxNKU2",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/rbjaxter/budhud/archive/master.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "#customization",
   "EnabledFolder": "#customization//_enabled",

--- a/src/TF2HUD.Editor/JSON/default.json
+++ b/src/TF2HUD.Editor/JSON/default.json
@@ -9,9 +9,15 @@
     "0 0 1 1"
   ],
   "Links": {
-    "Update": "https://github.com/CriticalFlaw/TF2HUD.Fixes/archive/refs/heads/community.zip",
+    "Update": "https://github.com/CriticalFlaw/TF2HUD.Fixes/archive/refs/heads/community.zip", // TODO: Remove
     "GitHub": "https://github.com/CriticalFlaw/TF2HUD.Fixes",
-    "Discord": "https://discord.gg/hTdtK9vBhE"
+    "Discord": "https://discord.gg/hTdtK9vBhE",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/CriticalFlaw/TF2HUD.Fixes/archive/refs/heads/community.zip"
+      }
+    ]
   },
   "Controls": {
     "Item Quality": [

--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -16,11 +16,21 @@
     "1 2 4 5"
   ],
   "Links": {
-    "Update": "https://github.com/CriticalFlaw/flawhud/archive/master.zip",
+    "Update": "https://github.com/CriticalFlaw/flawhud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/CriticalFlaw/flawhud",
     "HudsTF": "https://huds.tf/site/s-FlawHUD",
     "Steam": "https://steamcommunity.com/groups/FlawHUD",
-    "Discord": "https://discord.gg/hTdtK9vBhE"
+    "Discord": "https://discord.gg/hTdtK9vBhE",
+    "Download": [
+      {
+        "Source": "GitHub-Master",
+        "Link": "https://github.com/CriticalFlaw/flawhud/archive/master.zip"
+      },
+      {
+        "Source": "GitHub-Flaw",
+        "Link": "https://github.com/CriticalFlaw/flawhud/archive/flaw.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "resource//ui//#customizations",
   "EnabledFolder": "resource//ui//#customizations//_enabled",

--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -23,12 +23,8 @@
     "Discord": "https://discord.gg/hTdtK9vBhE",
     "Download": [
       {
-        "Source": "GitHub-Master",
+        "Source": "GitHub",
         "Link": "https://github.com/CriticalFlaw/flawhud/archive/master.zip"
-      },
-      {
-        "Source": "GitHub-Flaw",
-        "Link": "https://github.com/CriticalFlaw/flawhud/archive/flaw.zip"
       }
     ]
   },

--- a/src/TF2HUD.Editor/JSON/hexhud.json
+++ b/src/TF2HUD.Editor/JSON/hexhud.json
@@ -16,9 +16,15 @@
     "4 3 3"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/hexhud/archive/refs/heads/master.zip",
+    "Update": "https://github.com/Hypnootize/hexhud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/hexhud",
-    "HudsTF": "https://huds.tf/site/s-HExHUD--3435"
+    "HudsTF": "https://huds.tf/site/s-HExHUD--3435",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/Hypnootize/hexhud/archive/refs/heads/master.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "customizations",
   "EnabledFolder": "customizations",

--- a/src/TF2HUD.Editor/JSON/hypnotize-hud.json
+++ b/src/TF2HUD.Editor/JSON/hypnotize-hud.json
@@ -16,9 +16,15 @@
     "3 4 4"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/hypnotize-hud/archive/refs/heads/master.zip",
+    "Update": "https://github.com/Hypnootize/hypnotize-hud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/hypnotize-hud",
-    "HudsTF": "https://huds.tf/site/s-Hypnotize-Hud"
+    "HudsTF": "https://huds.tf/site/s-Hypnotize-Hud",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/Hypnootize/hypnotize-hud/archive/refs/heads/master.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "customizations",
   "EnabledFolder": "customizations",

--- a/src/TF2HUD.Editor/JSON/kbnhud.json
+++ b/src/TF2HUD.Editor/JSON/kbnhud.json
@@ -29,11 +29,17 @@
   //10-Spy & Engie Color Options
   //Refer to screenshot of this HUD's options for more visual aid, this file is meant to be a guide for newcomers as well as a working piece of code.
   "Links": {
-    "Update": "https://github.com/Jotunn/kbnhud/archive/master.zip",
+    "Update": "https://github.com/Jotunn/kbnhud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Jotunn/kbnhud",
     "HudsTF": "https://huds.tf/site/s-KBNHud",
     "Steam": "https://steamcommunity.com/groups/KBNHud",
-    "Discord": "https://discord.gg/NhnSysw"
+    "Discord": "https://discord.gg/NhnSysw",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/Jotunn/kbnhud/archive/master.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "^customizations",
   "EnabledFolder": "^customizations//#enabled",

--- a/src/TF2HUD.Editor/JSON/rayshud.json
+++ b/src/TF2HUD.Editor/JSON/rayshud.json
@@ -16,11 +16,17 @@
     "5 5 4 4 6 6"
   ],
   "Links": {
-    "Update": "https://github.com/raysfire/rayshud/archive/master.zip",
+    "Update": "https://github.com/raysfire/rayshud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/raysfire/rayshud",
     "HudsTF": "https://huds.tf/site/s-rayshud--377",
     "Steam": "https://steamcommunity.com/groups/rayshud",
-    "Discord": "https://discord.gg/hTdtK9vBhE"
+    "Discord": "https://discord.gg/hTdtK9vBhE",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/raysfire/rayshud/archive/master.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "#customizations",
   "EnabledFolder": "#customizations//_enabled",

--- a/src/TF2HUD.Editor/JSON/sunsethud.json
+++ b/src/TF2HUD.Editor/JSON/sunsethud.json
@@ -16,9 +16,15 @@
     "3 4 4"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/Sunset-Hud/archive/refs/heads/dark.zip",
+    "Update": "https://github.com/Hypnootize/Sunset-Hud/archive/refs/heads/dark.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/Sunset-Hud",
-    "HudsTF": "https://huds.tf/site/s-Sunset-Hud"
+    "HudsTF": "https://huds.tf/site/s-Sunset-Hud",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/Hypnootize/Sunset-Hud/archive/refs/heads/dark.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "customizations",
   "EnabledFolder": "customizations",

--- a/src/TF2HUD.Editor/JSON/zeeshud.json
+++ b/src/TF2HUD.Editor/JSON/zeeshud.json
@@ -16,8 +16,14 @@
     "6 6 3 3 1 1"
   ],
   "Links": {
-    "Update": "https://github.com/Zeesastrous/ZeesHUD/archive/refs/heads/main.zip",
-    "GitHub": "https://github.com/Zeesastrous/ZeesHUD"
+    "Update": "https://github.com/Zeesastrous/ZeesHUD/archive/refs/heads/main.zip", // TODO: Remove
+    "GitHub": "https://github.com/Zeesastrous/ZeesHUD",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/Zeesastrous/ZeesHUD/archive/refs/heads/main.zip"
+      }
+    ]
   },
   "CustomizationsFolder": "#customizations//addons",
   "EnabledFolder": "#customizations//addons//_enabled",

--- a/src/TF2HUD.Editor/MainWindow.xaml
+++ b/src/TF2HUD.Editor/MainWindow.xaml
@@ -228,6 +228,7 @@
                     Click="BtnSteam_OnClick"
                     Style="{StaticResource SteamButton}"
                     IsEnabled="{Binding Json.HighlightedHud.SteamUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
+                <ComboBox x:Name="CbBranch" Margin="5,5,5,0" Padding="5" Height="35" Visibility="{Binding Json.HighlightedHUD.Download, Converter={StaticResource NullCheckConverterVisibility}}" />
             </WrapPanel>
         </GroupBox>
     </Grid>

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -188,6 +188,17 @@ namespace HUDEditor
                 else
                     LblStatus.Content = Properties.Resources.status_pathNotSet;
 
+                CbBranch.Items.Clear();
+                foreach (var source in hud.Download)
+                {
+                    CbBranch.Items.Add(new ComboBoxItem
+                    {
+                        Tag = source.Source,
+                        Content = source.Link
+                    });
+                }
+                CbBranch.SelectedIndex = 0;
+
                 Application.Current.MainWindow.WindowState = hud.Maximize ? WindowState.Maximized : WindowState.Normal;
                 Settings.Default.hud_selected = hud.Name;
                 Settings.Default.Save();
@@ -361,7 +372,7 @@ namespace HUDEditor
 
                 // Retrieve the HUD object, then download and extract it into the tf/custom directory.
                 Logger.Info($"Start installing {HudSelection}.");
-                await Json.SelectedHud.Update();
+                await Json.SelectedHud.Update(CbBranch.SelectedValue.ToString());
 
                 // Record the name of the HUD inside the downloaded folder.
                 var tempFile = $"{AppDomain.CurrentDomain.BaseDirectory}temp.zip";
@@ -485,6 +496,7 @@ namespace HUDEditor
         private void BtnSwitch_OnClick(object sender, RoutedEventArgs e)
         {
             Logger.Info("Changing page view to: main menu.");
+            CbBranch.Visibility = Visibility.Hidden;
             EditorContainer.Children.Clear();
             Json.HighlightedHud = null;
             Json.SelectedHud = null;

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -193,11 +193,12 @@ namespace HUDEditor
                 {
                     CbBranch.Items.Add(new ComboBoxItem
                     {
-                        Tag = source.Source,
-                        Content = source.Link
+                        Tag = source.Link,
+                        Content = source.Source
                     });
                 }
                 CbBranch.SelectedIndex = 0;
+                CbBranch.Visibility = CbBranch.Items.Count > 1 ? Visibility.Visible : Visibility.Hidden;
 
                 Application.Current.MainWindow.WindowState = hud.Maximize ? WindowState.Maximized : WindowState.Normal;
                 Settings.Default.hud_selected = hud.Name;
@@ -344,7 +345,10 @@ namespace HUDEditor
         {
             try
             {
-                // Prevent switching HUD while installing to ensure that HighlightedHUD is the same as SelectedHUD at worker.RunWorkerCompleted
+                // Remember the selected download source, otherwise gets reset when SelectedHud is set.
+                var download = (ComboBoxItem)CbBranch.SelectedItem;
+
+                // Prevent switching HUD while installing to ensure that HighlightedHUD is the same as SelectedHUD at worker.
                 BtnSwitch.IsEnabled = false;
                 Json.SelectedHud = Json.HighlightedHud;
                 Settings.Default.hud_selected = HudSelection = Json.SelectedHud.Name;
@@ -372,7 +376,10 @@ namespace HUDEditor
 
                 // Retrieve the HUD object, then download and extract it into the tf/custom directory.
                 Logger.Info($"Start installing {HudSelection}.");
-                await Json.SelectedHud.Update(CbBranch.SelectedValue.ToString());
+                await Json.SelectedHud.Update(download.Tag.ToString());
+
+                // Set back the download source to what it is supposed to be.
+                CbBranch.SelectedItem = download;
 
                 // Record the name of the HUD inside the downloaded folder.
                 var tempFile = $"{AppDomain.CurrentDomain.BaseDirectory}temp.zip";

--- a/src/TF2HUD.Editor/Models/HudJson.cs
+++ b/src/TF2HUD.Editor/Models/HudJson.cs
@@ -28,7 +28,7 @@ namespace HUDEditor.Models
         [JsonPropertyName("GitHub")] public string GitHub;
         [JsonPropertyName("HudsTF")] public string HudsTf;
         [JsonPropertyName("Steam")] public string Steam;
-        [JsonPropertyName("Update")] public string Update;
+        [JsonPropertyName("Download")] public Download[] Download;
     }
 
     public class Controls
@@ -54,6 +54,12 @@ namespace HUDEditor.Models
         [JsonPropertyName("Type")] public string Type;
         [JsonPropertyName("Value")] public string Value = "0";
         [JsonPropertyName("Width")] public int Width;
+    }
+
+    public class Download
+    {
+        public string Source { get; set; }
+        public string Link { get; set; }
     }
 
     public class RenameFile

--- a/src/TF2HUD.Editor/Properties/Resources.Designer.cs
+++ b/src/TF2HUD.Editor/Properties/Resources.Designer.cs
@@ -331,7 +331,7 @@ namespace HUDEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Apply Changes.
+        ///   Looks up a localized string similar to Apply.
         /// </summary>
         public static string ui_apply {
             get {
@@ -439,7 +439,7 @@ namespace HUDEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reset to Default.
+        ///   Looks up a localized string similar to Reset.
         /// </summary>
         public static string ui_reset {
             get {
@@ -471,6 +471,15 @@ namespace HUDEditor.Properties {
         public static string ui_switch {
             get {
                 return ResourceManager.GetString("ui_switch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TF2 HUD Editor.
+        /// </summary>
+        public static string ui_title {
+            get {
+                return ResourceManager.GetString("ui_title", resourceCulture);
             }
         }
         

--- a/src/TF2HUD.Editor/Properties/Resources.Designer.cs
+++ b/src/TF2HUD.Editor/Properties/Resources.Designer.cs
@@ -331,7 +331,7 @@ namespace HUDEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Apply.
+        ///   Looks up a localized string similar to Apply Changes.
         /// </summary>
         public static string ui_apply {
             get {
@@ -439,7 +439,7 @@ namespace HUDEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reset.
+        ///   Looks up a localized string similar to Reset to Default.
         /// </summary>
         public static string ui_reset {
             get {

--- a/src/TF2HUD.Editor/Properties/Resources.resx
+++ b/src/TF2HUD.Editor/Properties/Resources.resx
@@ -208,7 +208,7 @@
     <value>Report an Issue.</value>
   </data>
   <data name="ui_apply" xml:space="preserve">
-    <value>Apply Changes</value>
+    <value>Apply</value>
   </data>
   <data name="ui_author" xml:space="preserve">
     <value>Created by: {0}</value>
@@ -244,7 +244,7 @@
     <value>Reinstall</value>
   </data>
   <data name="ui_reset" xml:space="preserve">
-    <value>Reset to Default</value>
+    <value>Reset</value>
   </data>
   <data name="ui_search" xml:space="preserve">
     <value>Search:</value>
@@ -254,6 +254,9 @@
   </data>
   <data name="ui_switch" xml:space="preserve">
     <value>Switch HUDs</value>
+  </data>
+  <data name="ui_title" xml:space="preserve">
+    <value>TF2 HUD Editor</value>
   </data>
   <data name="ui_uninstall" xml:space="preserve">
     <value>Uninstall</value>

--- a/src/TF2HUD.Editor/Properties/Resources.resx
+++ b/src/TF2HUD.Editor/Properties/Resources.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="error_app_directory" xml:space="preserve">
     <value>A tf/custom directory must be set in order to use this editor.</value>
@@ -208,7 +208,7 @@
     <value>Report an Issue.</value>
   </data>
   <data name="ui_apply" xml:space="preserve">
-    <value>Apply</value>
+    <value>Apply Changes</value>
   </data>
   <data name="ui_author" xml:space="preserve">
     <value>Created by: {0}</value>
@@ -244,7 +244,7 @@
     <value>Reinstall</value>
   </data>
   <data name="ui_reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>Reset to Default</value>
   </data>
   <data name="ui_search" xml:space="preserve">
     <value>Search:</value>


### PR DESCRIPTION
Changelog:
- Added support for multiple download paths. In the schema file, the new "Download" group can contain multiple sources, each with a display name and download link. The list will then be displayed on the button tray at the bottom of the screen.
- Updated the button tray UI to fit the download source dropdown.
- Updated schema files to adopt the new feature. Hopefully without breaking for current users.

Notes:
- The "Update" field can be removed from schema files after this feature is released and enough users migrate to 2.5.
- The UI change to fit the new download source dropdown could use another pass. It doesn't look too great at the moment.