### PR TITLE
Improved tf/custom directory handling.

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -38,9 +38,9 @@ If that didn't work, double-check that your antivirus program isn't denying acce
 ### Could not find a part of the path "..tf/custom".
 This can happen when TF2 is installed on a separate drive from your main Steam installation.
 
-If the app does not prompt you to set the path to `tf/custom` upon launch; you'll need to click on the dropdown button at the top right corner of the screen and select "Set path to tf/custom" then navigate to your TF2 installation folder, select tf/custom and click Select Folder.
+If the app does not find the directory to `tf/custom`, it should prompt you to set the path manually. If that does not happen, users will have to click on the wrench icon at near the bottom of screen to open the Options menu then select "Set path to tf/custom". You'll then need to navigate to your TF2 installation folder, select tf/custom and click Select Folder.
 
-For video instructions, check out this video by Hakej: https://www.youtube.com/watch?v=NqSqLyROBwk
+For HUD Editor versions 2.5 and lower, please refer to this video: https://www.youtube.com/watch?v=NqSqLyROBwk
 
 <!-- MARKDOWN LINKS -->
 [issues-link]: https://github.com/CriticalFlaw/TF2HUD.Editor/issues

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -11,7 +11,7 @@ You most likely downloaded the source code instead of the editor. On the [releas
 ---
 
 ### The editor does not launch after downloading and extracting it.
-Make sure to install the version of [Microsoft .NET 5.0 Runtime][runtime-link] inteded for running **desktop apps**. If you just installed it and the editor still does not launch, then restart your system.
+Make sure to install the version of [Microsoft .NET 6.0 Runtime][runtime-link] inteded for running **desktop apps**. If you just installed it and the editor still does not launch, then restart your system.
 
 ---
 
@@ -33,9 +33,18 @@ Try running the editor as administrator.
 
 If that didn't work, double-check that your antivirus program isn't denying access to the editor program. [For example,][example-avast-issue] Avast has been known to prevent the editor from creating files in certain paths.
 
+---
+
+### Could not find a part of the path "..tf/custom".
+This can happen when TF2 is installed on a separate drive from your main Steam installation.
+
+If the app does not prompt you to set the path to `tf/custom` upon launch; you'll need to click on the dropdown button at the top right corner of the screen and select "Set path to tf/custom" then navigate to your TF2 installation folder, select tf/custom and click Select Folder.
+
+For video instructions, check out this video by Hakej: https://www.youtube.com/watch?v=NqSqLyROBwk
+
 <!-- MARKDOWN LINKS -->
 [issues-link]: https://github.com/CriticalFlaw/TF2HUD.Editor/issues
 [discord-link]: https://discord.gg/hTdtK9vBhE
 [releases-link]: https://github.com/CriticalFlaw/TF2HUD.Editor/releases
-[runtime-link]: https://dotnet.microsoft.com/download/dotnet/5.0/runtime
+[runtime-link]: https://dotnet.microsoft.com/download/dotnet/6.0/runtime
 [example-avast-issue]: https://github.com/CriticalFlaw/TF2HUD.Editor/issues/107

--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -155,6 +155,31 @@
             </Style.Triggers>
         </Style>
 
+        <Style x:Key="SettingButton" TargetType="Button" BasedOn="{StaticResource HudButton}">
+            <Setter Property="Width" Value="400" />
+        </Style>
+
+        <Style x:Key="ToggleButton" TargetType="ToggleButton">
+            <Setter Property="FontFamily" Value="../Resources/TF2Build.ttf #TF2 Build" />
+            <Setter Property="FontSize" Value="16px" />
+            <Setter Property="Foreground" Value="#EBE2CA" />
+            <Setter Property="Background" Value="#776B5F" />
+            <Setter Property="Margin" Value="5" />
+            <Setter Property="Width" Value="400" />
+            <Setter Property="Height" Value="40" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#934739" />
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Foreground" Value="#2B2724" />
+                </Trigger>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter Property="Foreground" Value="#2B2724" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
         <Style x:Key="LinkButton" TargetType="Button">
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="VerticalAlignment" Value="Top" />

--- a/src/TF2HUD.Editor/App.xaml
+++ b/src/TF2HUD.Editor/App.xaml
@@ -239,6 +239,19 @@
             </Style.Triggers>
         </Style>
 
+        <Style x:Key="SettingsButton" TargetType="Button" BasedOn="{StaticResource LinkButton}">
+            <Setter Property="Content" Value="&#x0683;" />
+            <Setter Property="Width" Value="35" />
+            <Setter Property="Height" Value="35" />
+            <Setter Property="FontSize" Value="25" />
+            <Setter Property="Background" Value="#1B2838" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#384452" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
         <Style x:Key="PreviewButton" TargetType="Button">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="Foreground" Value="White" />

--- a/src/TF2HUD.Editor/HUDEditor.csproj
+++ b/src/TF2HUD.Editor/HUDEditor.csproj
@@ -64,6 +64,8 @@
     <PackageReference Include="Autoupdater.NET.Official" Version="1.7.5" />
     <PackageReference Include="CountryFlag" Version="2.1.0" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
+    <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
+    <PackageReference Include="Gameloop.Vdf.JsonConverter" Version="0.2.1" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WPFLocalizeExtension" Version="3.9.4" />

--- a/src/TF2HUD.Editor/HUDEditor.csproj
+++ b/src/TF2HUD.Editor/HUDEditor.csproj
@@ -62,6 +62,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autoupdater.NET.Official" Version="1.7.5" />
+    <PackageReference Include="CountryFlag" Version="2.1.0" />
     <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/TF2HUD.Editor/MainWindow.xaml
+++ b/src/TF2HUD.Editor/MainWindow.xaml
@@ -135,34 +135,23 @@
         </GroupBox>
         <!-- Editor Controls -->
         <Grid x:Name="EditorContainer">
-            <ToolBarPanel x:Name="EditorHeader" Grid.Row="0">
-                <Grid>
-                    <!-- HUD Status -->
-                    <Label x:Name="LblStatus" Content="..." Height="35" VerticalContentAlignment="Center" Margin="10" />
-                    <ToolBar Background="Transparent" ToolBarTray.IsLocked="True" Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,10,0">
-                        <Button
-                            Click="BtnGitHub_OnClick" Style="{StaticResource GitHubButton}"
-                            IsEnabled="{Binding Json.HighlightedHud.GitHubUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
-                        <Button
-                            Click="BtnHuds_OnClick" Style="{StaticResource HudsButton}"
-                            IsEnabled="{Binding Json.HighlightedHud.HudsTfUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
-                        <Button
-                            Click="BtnDiscord_OnClick" Style="{StaticResource DiscordButton}"
-                            IsEnabled="{Binding Json.HighlightedHud.DiscordUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
-                        <Button
-                            Click="BtnSteam_OnClick" Style="{StaticResource SteamButton}"
-                            IsEnabled="{Binding Json.HighlightedHud.SteamUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
-                        <Button Click="BtnSettings_Click" Style="{StaticResource SettingsButton}" />
-                        <!-- Localization -->
-                        <RadioButton x:Name="BtnLocalizeEn" Content="English" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
-                        <RadioButton x:Name="BtnLocalizeFr" Content="French" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
-                        <RadioButton x:Name="BtnLocalizeRu" Content="Russian" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
-                        <Button Content="{lex:Loc ui_directory}" Click="BtnSetDirectory_OnClick" ToolBar.OverflowMode="Always" />
-                        <Button Content="{lex:Loc ui_refresh}" Click="BtnRefresh_OnClick" ToolBar.OverflowMode="Always" />
-                        <ToggleButton x:Name="BtnAutoUpdate" Content="{lex:Loc ui_check_updates}" Click="BtnAutoUpdate_OnClick" ToolBar.OverflowMode="Always" />
-                    </ToolBar>
-                </Grid>
-            </ToolBarPanel>
+            <Label x:Name="LblStatus" Content="..." Height="35" VerticalContentAlignment="Center" Margin="10" />
+            <WrapPanel HorizontalAlignment="Right" Margin="0,5,15,0">
+                <Label x:Name="LblDownload" Content="{lex:Loc ui_download}" Margin="0,8,0,10" Visibility="{Binding Json.HighlightedHud.Download, Converter={StaticResource NullCheckConverterVisibility}}" />
+                <ComboBox x:Name="CbBranch" Margin="5,5,5,0" Padding="5" Height="35" Width="150" Visibility="{Binding Json.HighlightedHud.Download, Converter={StaticResource NullCheckConverterVisibility}}" />
+                <Button
+                    Click="BtnGitHub_OnClick" Style="{StaticResource GitHubButton}"
+                    IsEnabled="{Binding Json.HighlightedHud.GitHubUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
+                <Button
+                    Click="BtnHuds_OnClick" Style="{StaticResource HudsButton}"
+                    IsEnabled="{Binding Json.HighlightedHud.HudsTfUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
+                <Button
+                    Click="BtnDiscord_OnClick" Style="{StaticResource DiscordButton}"
+                    IsEnabled="{Binding Json.HighlightedHud.DiscordUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
+                <Button
+                    Click="BtnSteam_OnClick" Style="{StaticResource SteamButton}"
+                    IsEnabled="{Binding Json.HighlightedHud.SteamUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
+            </WrapPanel>
             <Grid x:Name="EditorGrid" />
         </Grid>
         <!-- Bottom Button Tray -->
@@ -195,6 +184,11 @@
                     Style="{StaticResource HudButton}"
                     IsEnabled="{Binding Json.SelectedHud, Converter={StaticResource NullCheckConverter}}" />
                 <Button
+                    Click="BtnSettings_OnClick"
+                    Content="="
+                    ToolTip="{lex:Loc ui_options}"
+                    Style="{StaticResource LinkButton}" />
+                <Button
                     Click="BtnReportIssue_OnClick"
                     Content="&#x03C6;"
                     ToolTip="{lex:Loc tooltip_report}"
@@ -205,12 +199,16 @@
                     ToolTip="{lex:Loc tooltip_docs}"
                     Style="{StaticResource LinkButton}" />
                 <Button
+                    Click="BtnPlayTF2_OnClick"
+                    Content="!"
+                    ToolTip="{lex:Loc ui_launch_tf2}"
+                    Style="{StaticResource LinkButton}" />
+                <Button
                     Click="BtnAddSharedHUD_OnClick"
                     Content="&#x0583;"
                     Style="{StaticResource LinkButton}"
                     ToolTip="{lex:Loc tooltip_addhud}"
                     IsEnabled="{Binding Json.SelectedHud, Converter={StaticResource NotNullCheckConverter}}" />
-                <ComboBox x:Name="CbBranch" Margin="5,5,5,0" Padding="5" Height="35" Width="150" Visibility="{Binding Json.HighlightedHud.Download, Converter={StaticResource NullCheckConverterVisibility}}" />
             </WrapPanel>
         </GroupBox>
     </Grid>

--- a/src/TF2HUD.Editor/MainWindow.xaml
+++ b/src/TF2HUD.Editor/MainWindow.xaml
@@ -76,18 +76,9 @@
                             <Run Foreground="#FFD700" Text="documentation" /><Run Text=" linked below." />
                         </TextBlock>
                         <Border Background="#A49E9E" HorizontalAlignment="Stretch" Height="1" Margin="0,15,0,10" />
-                        <Label Content="Version 2.5" Style="{StaticResource HeaderText}" Margin="0,0,0,10" />
+                        <Label Content="Version 2.6" Style="{StaticResource HeaderText}" Margin="0,0,0,10" />
                         <TextBlock Style="{StaticResource BodyText}" FontSize="22" TextAlignment="Left">
-                            <Run Text="* Upgraded the project to the latest version of NET (6.0)." /><LineBreak />
-                            <Run Text="* Added support for Sunset Hud and KBNHud." /><LineBreak />
-                            <Run Text="* Added a validation checks for unsupported HUDs." /><LineBreak />
-                            <Run Text="* Added Brazilian Portuguese localization." /><LineBreak />
-                            <Run Text="* Added scrollers to customization screens that don't fit everything." /><LineBreak />
-                            <Run Text="* Added support for multiple download sources of the same HUD." /><LineBreak />
-                            <Run Text="* Added an option to hide the player list to certain HUDS." /><LineBreak />
-                            <Run Text="* Hypnotize's Crosshair Pack can now be installed for certain HUDs." /><LineBreak />
-                            <Run Text="* Changed the icons used in the app to Hypnotize's Icons Pack." /><LineBreak />
-                            <Run Text="* Various backend improvements and optimizations." />
+                            <Run Text="* TOOOOOODOOOOOOOO" /><LineBreak />
                         </TextBlock>
                     </StackPanel>
                 </ScrollViewer>
@@ -161,6 +152,7 @@
                         <Button
                             Click="BtnSteam_OnClick" Style="{StaticResource SteamButton}"
                             IsEnabled="{Binding Json.HighlightedHud.SteamUrl, Converter={StaticResource NullCheckConverter}, FallbackValue=False}" />
+                        <Button Click="BtnSettings_Click" Style="{StaticResource SettingsButton}" />
                         <!-- Localization -->
                         <RadioButton x:Name="BtnLocalizeEn" Content="English" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
                         <RadioButton x:Name="BtnLocalizeFr" Content="French" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using HUDEditor.Properties;
 using log4net;
 using log4net.Config;
 using WPFLocalizeExtension.Engine;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 using Application = System.Windows.Application;
 using Binding = System.Windows.Data.Binding;
 using Label = System.Windows.Controls.Label;
@@ -25,7 +26,7 @@ using MessageBox = System.Windows.MessageBox;
 namespace HUDEditor
 {
     /// <summary>
-    ///     Interaction logic for MainWindow.xaml
+    /// Interaction logic for MainWindow.xaml
     /// </summary>
     public partial class MainWindow
     {
@@ -589,6 +590,12 @@ namespace HUDEditor
         private void BtnSteam_OnClick(object sender, RoutedEventArgs e)
         {
             Utilities.OpenWebpage(Json.HighlightedHud.SteamUrl);
+        }
+
+        private void BtnSettings_Click(object sender, RoutedEventArgs e)
+        {
+            var settings = new SettingsWindow();
+            settings.Show();
         }
 
         /// <summary>

--- a/src/TF2HUD.Editor/MainWindow.xaml.cs
+++ b/src/TF2HUD.Editor/MainWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -16,8 +15,6 @@ using HUDEditor.Classes;
 using HUDEditor.Properties;
 using log4net;
 using log4net.Config;
-using WPFLocalizeExtension.Engine;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 using Application = System.Windows.Application;
 using Binding = System.Windows.Data.Binding;
 using Label = System.Windows.Controls.Label;
@@ -60,8 +57,7 @@ namespace HUDEditor
             Json.SelectionChanged += SelectionChanged;
 
             // Check for app updates.
-            BtnAutoUpdate.IsChecked = Settings.Default.app_update_auto;
-            if (BtnAutoUpdate.IsChecked == true)
+            if (Settings.Default.app_update_auto == true)
                 CheckSchemaUpdates();
 
             Logger.Info("Checking for app updates.");
@@ -74,7 +70,7 @@ namespace HUDEditor
         ///     Setup the tf/custom directory, if it's not already set.
         /// </summary>
         /// <param name="userSet">Flags the process as being user initiated, skip right to the folder browser.</param>
-        private void SetupDirectory(bool userSet = false)
+        public static void SetupDirectory(bool userSet = false)
         {
             if ((Utilities.SearchRegistry() || Utilities.CheckUserPath(HudPath)) && !userSet) return;
             // Display a folder browser, ask the user to provide the tf/custom directory.
@@ -201,6 +197,7 @@ namespace HUDEditor
                 }
                 CbBranch.SelectedIndex = LastDownloadSource;
                 CbBranch.Visibility = CbBranch.Items.Count > 1 ? Visibility.Visible : Visibility.Hidden;
+                LblDownload.Visibility = CbBranch.Visibility;
 
                 Application.Current.MainWindow.WindowState = hud.Maximize ? WindowState.Maximized : WindowState.Normal;
                 Settings.Default.hud_selected = hud.Name;
@@ -517,15 +514,10 @@ namespace HUDEditor
             Logger.Info("Changing page view to: main menu.");
             EditorGrid.Children.Clear();
             EditorContainer.Visibility = Visibility.Hidden;
+            LblDownload.Visibility = Visibility.Hidden;
             CbBranch.Visibility = Visibility.Hidden;
             Json.HighlightedHud = null;
             Json.SelectedHud = null;
-        }
-
-        private void BtnSetDirectory_OnClick(object sender, RoutedEventArgs e)
-        {
-            Logger.Info("Attempting to change the 'tf/custom' directory.");
-            SetupDirectory(true);
         }
 
         /// <summary>
@@ -560,16 +552,28 @@ namespace HUDEditor
         }
 
         /// <summary>
+        ///     Opens the settings menu for the editor.
+        /// </summary>
+        private void BtnSettings_OnClick(object sender, RoutedEventArgs e)
+        {
+            var settings = new SettingsWindow();
+            settings.Show();
+        }
+
+        /// <summary>
+        ///     Opens the settings menu for the editor.
+        /// </summary>
+        private void BtnPlayTF2_OnClick(object sender, RoutedEventArgs e)
+        {
+            System.Diagnostics.Process.Start(@"steam://rungameid/440");
+        }
+
+        /// <summary>
         ///     Opens the project documentation site.
         /// </summary>
         private void BtnDocumentation_OnClick(object sender, RoutedEventArgs e)
         {
             Utilities.OpenWebpage(Settings.Default.app_docs);
-        }
-
-        private void BtnRefresh_OnClick(object sender, RoutedEventArgs e)
-        {
-            CheckSchemaUpdates(false);
         }
 
         private void BtnGitHub_OnClick(object sender, RoutedEventArgs e)
@@ -592,29 +596,6 @@ namespace HUDEditor
             Utilities.OpenWebpage(Json.HighlightedHud.SteamUrl);
         }
 
-        private void BtnSettings_Click(object sender, RoutedEventArgs e)
-        {
-            var settings = new SettingsWindow();
-            settings.Show();
-        }
-
-        /// <summary>
-        ///     Updates localization to the selected language.
-        /// </summary>
-        private void BtnLocalize_OnClick(object sender, RoutedEventArgs e)
-        {
-            if (BtnLocalizeEn.IsChecked == true)
-                LocalizeDictionary.Instance.Culture = new CultureInfo("en-US");
-            else if (BtnLocalizeFr.IsChecked == true)
-                LocalizeDictionary.Instance.Culture = new CultureInfo("fr-FR");
-            else if (BtnLocalizeRu.IsChecked == true)
-                LocalizeDictionary.Instance.Culture = new CultureInfo("ru-RU");
-
-            // Save language preference to user settings.
-            Settings.Default.user_language = LocalizeDictionary.Instance.Culture.ToString();
-            Settings.Default.Save();
-        }
-
         private void BtnCustomize_OnClick(object sender, RoutedEventArgs e)
         {
             if (Json.HighlightedHud is null) return;
@@ -623,12 +604,6 @@ namespace HUDEditor
             Settings.Default.hud_selected = Json.SelectedHud.Name;
             Settings.Default.Save();
             SetPageView(Json[Settings.Default.hud_selected]);
-        }
-
-        private void BtnAutoUpdate_OnClick(object sender, RoutedEventArgs e)
-        {
-            Settings.Default.app_update_auto = BtnAutoUpdate.IsChecked ?? true;
-            Settings.Default.Save();
         }
 
         #endregion CLICK_EVENTS

--- a/src/TF2HUD.Editor/Models/GitJson.cs
+++ b/src/TF2HUD.Editor/Models/GitJson.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace HUDEditor.Models
+{
+    public class GitJson
+    {
+        [JsonPropertyName("name")] public string Name { get; set; }
+        [JsonPropertyName("sha")] public string SHA { get; set; }
+        [JsonPropertyName("download_url")] public string Download { get; set; }
+        [JsonPropertyName("type")] public string Type { get; set; }
+    }
+}

--- a/src/TF2HUD.Editor/Models/HudJson.cs
+++ b/src/TF2HUD.Editor/Models/HudJson.cs
@@ -79,12 +79,4 @@ namespace HUDEditor.Models
         [JsonPropertyName("SpecialParameters")] public string[] SpecialParameters;
         [JsonPropertyName("Value")] public string Value;
     }
-
-    public class GitJson
-    {
-        [JsonPropertyName("name")] public string Name { get; set; }
-        [JsonPropertyName("sha")] public string SHA { get; set; }
-        [JsonPropertyName("download_url")] public string Download { get; set; }
-        [JsonPropertyName("type")] public string Type { get; set; }
-    }
 }

--- a/src/TF2HUD.Editor/Models/SteamModel.cs
+++ b/src/TF2HUD.Editor/Models/SteamModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace HUDEditor.Models
+{
+    public class SteamModel
+    {
+        [JsonPropertyName("path")] public string Path { get; set; }
+        [JsonPropertyName("label")] public string Label { get; set; }
+    }
+}

--- a/src/TF2HUD.Editor/Properties/Resources.Designer.cs
+++ b/src/TF2HUD.Editor/Properties/Resources.Designer.cs
@@ -403,11 +403,29 @@ namespace HUDEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Download:.
+        /// </summary>
+        public static string ui_download {
+            get {
+                return ResourceManager.GetString("ui_download", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Install.
         /// </summary>
         public static string ui_install {
             get {
                 return ResourceManager.GetString("ui_install", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Launch Team Fortress 2..
+        /// </summary>
+        public static string ui_launch_tf2 {
+            get {
+                return ResourceManager.GetString("ui_launch_tf2", resourceCulture);
             }
         }
         

--- a/src/TF2HUD.Editor/Properties/Resources.resx
+++ b/src/TF2HUD.Editor/Properties/Resources.resx
@@ -231,8 +231,14 @@
   <data name="ui_directory" xml:space="preserve">
     <value>Set path to tf/custom</value>
   </data>
+  <data name="ui_download" xml:space="preserve">
+    <value>Download:</value>
+  </data>
   <data name="ui_install" xml:space="preserve">
     <value>Install</value>
+  </data>
+  <data name="ui_launch_tf2" xml:space="preserve">
+    <value>Launch Team Fortress 2.</value>
   </data>
   <data name="ui_options" xml:space="preserve">
     <value>Options</value>

--- a/src/TF2HUD.Editor/SettingsWindow.xaml
+++ b/src/TF2HUD.Editor/SettingsWindow.xaml
@@ -9,10 +9,11 @@
         lex:ResxLocalizationProvider.DefaultAssembly="TF2HUD.Editor"
         lex:ResxLocalizationProvider.DefaultDictionary="Resources"
         mc:Ignorable="d"
-        Title="{lex:Loc ui_title}"
-        Width="1320"
-        Height="850"
+        Title="{lex:Loc ui_options}"
+        Width="1000"
+        Height="600"
         WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
         FontFamily="../Resources/TF2Secondary.ttf #TF2 Secondary"
         FontSize="20px"
         Background="#2B2724">
@@ -36,10 +37,29 @@
                             <Run Foreground="#FFD700" Text="documentation" /><Run Text=" linked below." />
                 </TextBlock>
                 <Border Background="#A49E9E" HorizontalAlignment="Stretch" Height="1" Margin="0,15,0,10" />
-                <Label Content="Version 2.6" Style="{StaticResource HeaderText}" Margin="0,0,0,10" />
-                <TextBlock Style="{StaticResource BodyText}" FontSize="22" TextAlignment="Left">
-                    <Run Text="* TOOOOOODOOOOOOOO" /><LineBreak />
-                </TextBlock>
+                <GroupBox Header="Language" Grid.Row="1" Foreground="White">
+                    <WrapPanel HorizontalAlignment="Center">
+                        <RadioButton x:Name="BtnLocalizeEn" Content="English" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
+                        <RadioButton x:Name="BtnLocalizeFr" Content="French" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
+                        <RadioButton x:Name="BtnLocalizeRu" Content="Russian" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
+                    </WrapPanel>
+                </GroupBox>
+                <GroupBox Header="{lex:Loc ui_options}" Grid.Row="1">
+                    <WrapPanel HorizontalAlignment="Center">
+                        <Button
+                            Content="{lex:Loc ui_directory}"
+                            Click="BtnSetDirectory_OnClick"
+                            Style="{StaticResource HudButton}" />
+                        <Button
+                            Content="{lex:Loc ui_refresh}"
+                            Click="BtnRefresh_OnClick"
+                            Style="{StaticResource HudButton}" />
+                        <ToggleButton
+                            x:Name="BtnAutoUpdate"
+                            Content="{lex:Loc ui_check_updates}"
+                            Click="BtnAutoUpdate_OnClick" />
+                    </WrapPanel>
+                </GroupBox>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/TF2HUD.Editor/SettingsWindow.xaml
+++ b/src/TF2HUD.Editor/SettingsWindow.xaml
@@ -1,0 +1,46 @@
+﻿<Window x:Class="HUDEditor.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:lex="http://wpflocalizeextension.codeplex.com"
+        xmlns:classes="clr-namespace:HUDEditor.Classes"
+        lex:LocalizeDictionary.DesignCulture="en"
+        lex:ResxLocalizationProvider.DefaultAssembly="TF2HUD.Editor"
+        lex:ResxLocalizationProvider.DefaultDictionary="Resources"
+        mc:Ignorable="d"
+        Title="{lex:Loc ui_title}"
+        Width="1320"
+        Height="850"
+        WindowStartupLocation="CenterScreen"
+        FontFamily="../Resources/TF2Secondary.ttf #TF2 Secondary"
+        FontSize="20px"
+        Background="#2B2724">
+    <Window.Resources>
+        <classes:NullCheckConverter x:Key="NullCheckConverter" />
+        <classes:NotNullCheckConverter x:Key="NotNullCheckConverter" />
+        <classes:NullCheckConverterVisibility x:Key="NullCheckConverterVisibility" />
+        <classes:NotNullCheckConverterVisibility x:Key="NotNullCheckConverterVisibility" />
+        <classes:BtnInstallContentConverter x:Key="BtnInstallContentConverter" />
+        <classes:PageBackgroundConverter x:Key="PageBackgroundConverter" />
+    </Window.Resources>
+    <Grid>
+        <!-- App Info and Changelog -->
+        <ScrollViewer VerticalScrollBarVisibility="Hidden" Grid.Column="1" Grid.Row="0" Visibility="{Binding Json.HighlightedHud, Converter={StaticResource NotNullCheckConverterVisibility}}">
+            <StackPanel Margin="20">
+                <Image Source="Resources/banner.png" Height="142" Width="621" Margin="0,0,0,15" />
+                <TextBlock Style="{StaticResource BodyText}" FontSize="21" TextAlignment="Center">
+                            <Run Foreground="#70B04A" Text="Install" /><Run Text=" and" />
+                            <Run Foreground="#38F3AB" Text="customize" />
+                            <Run Text="your favorite Team Fortress 2 HUDs! For additional information and support, check out the" />
+                            <Run Foreground="#FFD700" Text="documentation" /><Run Text=" linked below." />
+                </TextBlock>
+                <Border Background="#A49E9E" HorizontalAlignment="Stretch" Height="1" Margin="0,15,0,10" />
+                <Label Content="Version 2.6" Style="{StaticResource HeaderText}" Margin="0,0,0,10" />
+                <TextBlock Style="{StaticResource BodyText}" FontSize="22" TextAlignment="Left">
+                    <Run Text="* TOOOOOODOOOOOOOO" /><LineBreak />
+                </TextBlock>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Window>

--- a/src/TF2HUD.Editor/SettingsWindow.xaml
+++ b/src/TF2HUD.Editor/SettingsWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:lex="http://wpflocalizeextension.codeplex.com"
         xmlns:classes="clr-namespace:HUDEditor.Classes"
+        xmlns:cf="clr-namespace:CountryFlag;assembly=CountryFlag"
         lex:LocalizeDictionary.DesignCulture="en"
         lex:ResxLocalizationProvider.DefaultAssembly="TF2HUD.Editor"
         lex:ResxLocalizationProvider.DefaultDictionary="Resources"
@@ -39,9 +40,15 @@
                 <Border Background="#A49E9E" HorizontalAlignment="Stretch" Height="1" Margin="0,15,0,10" />
                 <GroupBox Header="Language" Grid.Row="1" Foreground="White">
                     <WrapPanel HorizontalAlignment="Center">
-                        <RadioButton x:Name="BtnLocalizeEn" Content="English" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
-                        <RadioButton x:Name="BtnLocalizeFr" Content="French" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
-                        <RadioButton x:Name="BtnLocalizeRu" Content="Russian" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" />
+                        <RadioButton x:Name="BtnLocalizeEn" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" Margin="5">
+                            <cf:CountryFlag Code="US" Width="60" />
+                        </RadioButton>
+                        <RadioButton x:Name="BtnLocalizeFr" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" Margin="5">
+                            <cf:CountryFlag Code="FR" Width="50" />
+                        </RadioButton>
+                        <RadioButton x:Name="BtnLocalizeRu" Checked="BtnLocalize_OnClick" ToolBar.OverflowMode="Always" Margin="5">
+                            <cf:CountryFlag Code="RU" Width="50" />
+                        </RadioButton>
                     </WrapPanel>
                 </GroupBox>
                 <GroupBox Header="{lex:Loc ui_options}" Grid.Row="1">
@@ -49,15 +56,16 @@
                         <Button
                             Content="{lex:Loc ui_directory}"
                             Click="BtnSetDirectory_OnClick"
-                            Style="{StaticResource HudButton}" />
+                            Style="{StaticResource SettingButton}" />
                         <Button
                             Content="{lex:Loc ui_refresh}"
                             Click="BtnRefresh_OnClick"
-                            Style="{StaticResource HudButton}" />
+                            Style="{StaticResource SettingButton}" />
                         <ToggleButton
                             x:Name="BtnAutoUpdate"
                             Content="{lex:Loc ui_check_updates}"
-                            Click="BtnAutoUpdate_OnClick" />
+                            Click="BtnAutoUpdate_OnClick"
+                            Style="{StaticResource ToggleButton}" />
                     </WrapPanel>
                 </GroupBox>
             </StackPanel>

--- a/src/TF2HUD.Editor/SettingsWindow.xaml.cs
+++ b/src/TF2HUD.Editor/SettingsWindow.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows;
+
+namespace HUDEditor
+{
+    /// <summary>
+    /// Interaction logic for Settings.xaml
+    /// </summary>
+    public partial class SettingsWindow : Window
+    {
+        public SettingsWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/TF2HUD.Editor/SettingsWindow.xaml.cs
+++ b/src/TF2HUD.Editor/SettingsWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows;
+﻿using System.Globalization;
+using System.Windows;
+using HUDEditor.Properties;
+using WPFLocalizeExtension.Engine;
 
 namespace HUDEditor
 {
@@ -10,6 +13,43 @@ namespace HUDEditor
         public SettingsWindow()
         {
             InitializeComponent();
+
+            // Check for app updates.
+            BtnAutoUpdate.IsChecked = Settings.Default.app_update_auto;
+        }
+
+        /// <summary>
+        ///     Updates localization to the selected language.
+        /// </summary>
+        private void BtnLocalize_OnClick(object sender, RoutedEventArgs e)
+        {
+            if (BtnLocalizeEn.IsChecked == true)
+                LocalizeDictionary.Instance.Culture = new CultureInfo("en-US");
+            else if (BtnLocalizeFr.IsChecked == true)
+                LocalizeDictionary.Instance.Culture = new CultureInfo("fr-FR");
+            else if (BtnLocalizeRu.IsChecked == true)
+                LocalizeDictionary.Instance.Culture = new CultureInfo("ru-RU");
+
+            // Save language preference to user settings.
+            Settings.Default.user_language = LocalizeDictionary.Instance.Culture.ToString();
+            Settings.Default.Save();
+        }
+
+        private void BtnSetDirectory_OnClick(object sender, RoutedEventArgs e)
+        {
+            MainWindow.Logger.Info("Attempting to change the 'tf/custom' directory.");
+            MainWindow.SetupDirectory(true);
+        }
+
+        private void BtnRefresh_OnClick(object sender, RoutedEventArgs e)
+        {
+            MainWindow.CheckSchemaUpdates(false);
+        }
+
+        private void BtnAutoUpdate_OnClick(object sender, RoutedEventArgs e)
+        {
+            Settings.Default.app_update_auto = BtnAutoUpdate.IsChecked ?? true;
+            Settings.Default.Save();
         }
     }
 }


### PR DESCRIPTION
- Updated the Troubleshooting page of the docs to describe the workaround steps in case the editor fails to find the `tf/custom` directory on its own - even after these changes.
- Updated the docs to link to the correct .NET runtime version.
- Created a new page for application settings. The page will be refined prior to release of 2.6.
- Language options are now represented with country flags.

![image](https://user-images.githubusercontent.com/6818236/194672133-8bd49194-652e-4578-b6b0-97fcdf3f6c0d.png)

- The main UI has been updated to accommodate the above change. Instead of a dropdown menu, the options are now accessible using the wrench icon at the bottom of the screen. The download source dropdown will now be displayed on the top of the screen to the left of the social media links.
- Added a button for launching Team Fortress 2, though it seems to be buggy at the moment.

![image](https://user-images.githubusercontent.com/6818236/194672126-84418111-20bd-4db0-aded-a55d799c34a2.png)


