### PR TITLE
Fixing ClassLabel not being centered in FlawHud

### DIFF
--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -1414,6 +1414,7 @@
                 },
                 "ClassLabel": {
                   "font": "FontBold22",
+                  "textAlignment":	"center",
                   "xpos": "c-120",
                   "ypos": "17",
                   "wide": "240",


### PR DESCRIPTION
Changing the value of `textAlignment` to `center` fixes the issue I wrote about in https://github.com/CriticalFlaw/flawhud/issues/254

**BEFORE:**
![image](https://user-images.githubusercontent.com/47070328/198898437-6e202e97-24e9-4000-8609-3d394893a86c.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/47070328/198898452-2759f867-768b-4345-ac9c-a4e33c3bc19b.png)
