### PR TITLE
[FLAWHUD] fix for mode selection text

### DIFF
--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -1341,10 +1341,6 @@
                 "true": "FontBold18",
                 "false": "FontBold12"
               },
-              "textAlignment": {
-                "true": "center",
-                "false": "north"
-              }
             }
           },
           "resource/ui/matchmakingdashboardplaylist.res": {


### PR DESCRIPTION
The text should e centered in both old and new mode selections, no point in changing the value back to `north` when `Old Mode Selection` is false