### PR TITLE
3.2

### DIFF
--- a/Update.xml
+++ b/Update.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
-    <version>3.1.0.0</version>
-    <url>https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.1/tf2hud-editor-x64.zip</url>
-    <changelog>https://github.com/CriticalFlaw/TF2HUD.Editor/releases/tag/3.1</changelog>
+    <version>3.2.0.0</version>
+    <url>https://github.com/CriticalFlaw/TF2HUD.Editor/releases/download/3.2/tf2hud-editor-x64.zip</url>
+    <changelog>https://github.com/CriticalFlaw/TF2HUD.Editor/releases/tag/3.2</changelog>
     <mandatory>true</mandatory>
 </item>

--- a/src/TF2HUD.Editor/Classes/HUD/HUDCustomizations.cs
+++ b/src/TF2HUD.Editor/Classes/HUD/HUDCustomizations.cs
@@ -228,12 +228,10 @@ namespace HUDEditor.Classes
                                     if (option.RenameFile.OldName.EndsWith('/'))
                                     {
                                         if (Directory.Exists(path + option.RenameFile.NewName))
-                                            Directory.Move(path + option.RenameFile.NewName,
-                                                path + option.RenameFile.OldName);
+                                            Directory.Move(path + option.RenameFile.NewName, path + option.RenameFile.OldName);
 
                                         if (string.Equals(option.Value, setting.Value))
-                                            Directory.Move(path + option.RenameFile.OldName,
-                                                path + option.RenameFile.NewName);
+                                            Directory.Move(path + option.RenameFile.OldName, path + option.RenameFile.NewName);
                                     }
                                     else
                                     {
@@ -250,25 +248,26 @@ namespace HUDEditor.Classes
                                 // Move every file assigned to this control back to the customization folder first.
                                 foreach (string file in fileNames)
                                 {
-                                    var name = file.Replace(".res", string.Empty);
-                                    if (Directory.Exists(enabled + $"\\{name}"))
-                                        Directory.Move(enabled + $"\\{name}", custom + $"\\{name}");
-                                    else if (File.Exists(enabled + $"\\{name}.res"))
-                                        File.Move(enabled + $"\\{name}.res", custom + $"\\{name}.res", true);
+                                    var dir = file.Replace(".res", string.Empty);
+                                    if (Directory.Exists(enabled + $"\\{dir}"))
+                                        Directory.Move(enabled + $"\\{dir}", custom + $"\\{dir}");
+                                    else if (File.Exists(enabled + $"\\{file}"))
+                                        File.Move(enabled + $"\\{file}", custom + $"\\{file}", true);
                                 }
 
-                                // Only move the files for the control option selected by the user.
-                                if (!string.Equals(setting.Value, "0"))
+                                var name = control.Options[int.Parse(setting.Value)].FileName;
+                                if (string.IsNullOrWhiteSpace(name)) break;
+
+                                name = name.Replace(".res", string.Empty);
+                                if (Directory.Exists(custom + $"\\{name}"))
                                 {
-                                    var name = control.Options[int.Parse(setting.Value)].FileName;
-                                    if (string.IsNullOrWhiteSpace(name)) break;
-
-                                    name = name.Replace(".res", string.Empty);
-                                    if (Directory.Exists(custom + $"\\{name}"))
+                                    if (control.ComboDirectories is not null)
+                                        CopyDirectory(custom + $"\\{name}", enabled);
+                                    else
                                         Directory.Move(custom + $"\\{name}", enabled + $"\\{name}");
-                                    else if (File.Exists(custom + $"\\{name}.res"))
-                                        File.Move(custom + $"\\{name}.res", enabled + $"\\{name}.res", true);
                                 }
+                                else if (File.Exists(custom + $"\\{name}.res"))
+                                    File.Move(custom + $"\\{name}.res", enabled + $"\\{name}.res", true);
 
                                 break;
                         }
@@ -784,6 +783,33 @@ namespace HUDEditor.Classes
             catch (Exception e)
             {
                 MainWindow.ShowMessageBox(MessageBoxImage.Error, string.Format(Utilities.GetLocalizedString("error_transparent_vm"), e.Message));
+            }
+        }
+
+        /// <summary>
+        ///     Function for copying multiple files and subdirectories, recursively.
+        /// </summary>
+        static void CopyDirectory(string source, string destination)
+        {
+            // Get information about the source directory.
+            var dir = new DirectoryInfo(source);
+
+            // Cache directories before we start copying.
+            var dirs = dir.GetDirectories();
+
+            // Get the files in the source directory and copy to the destination directory
+            foreach (var file in dir.GetFiles())
+            {
+                string targetFilePath = Path.Combine(destination, file.Name);
+                if (file.Name.Contains(".jpg") || file.Name.Contains(".png")) continue;
+                file.CopyTo(targetFilePath, true);
+            }
+
+            // Recursively call this method copy subdirectories.
+            foreach (var subDir in dirs)
+            {
+                string newDestinationDir = Path.Combine(destination, subDir.Name);
+                CopyDirectory(subDir.FullName, newDestinationDir);
             }
         }
     }

--- a/src/TF2HUD.Editor/Classes/Utilities.cs
+++ b/src/TF2HUD.Editor/Classes/Utilities.cs
@@ -199,7 +199,7 @@ namespace HUDEditor.Classes
         {
             if (!string.IsNullOrWhiteSpace(control.FileName))
                 return control.FileName.Replace(".res", string.Empty);
-            return control.ComboFiles;
+            return (control.ComboDirectories is not null) ? control.ComboDirectories : control.ComboFiles;
         }
 
         /// <summary>

--- a/src/TF2HUD.Editor/HUDEditor.csproj
+++ b/src/TF2HUD.Editor/HUDEditor.csproj
@@ -11,9 +11,9 @@
 		<Company>CriticalFlaw</Company>
 		<Copyright>CriticalFlaw</Copyright>
 		<PackageProjectUrl>http://criticalflaw.ca/TF2HUD.Editor/</PackageProjectUrl>
-		<AssemblyVersion>3.1.0.0</AssemblyVersion>
-		<FileVersion>3.1.0.0</FileVersion>
-		<Version>3.1.0</Version>
+		<AssemblyVersion>3.2.0.0</AssemblyVersion>
+		<FileVersion>3.2.0.0</FileVersion>
+		<Version>3.2.0</Version>
 		<RepositoryUrl>https://github.com/CriticalFlaw/TF2HUD.Editor</RepositoryUrl>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -68,7 +68,7 @@
 		<PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
 		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Octokit" Version="7.0.1" />
+		<PackageReference Include="Octokit" Version="7.1.0" />
 		<PackageReference Include="WPFLocalizeExtension" Version="3.10.0" />
 	</ItemGroup>
 

--- a/src/TF2HUD.Editor/HUDEditor.csproj
+++ b/src/TF2HUD.Editor/HUDEditor.csproj
@@ -42,6 +42,7 @@
 		<None Remove="JSON\hud-fixes.json" />
 		<None Remove="JSON\hypnotize-hud.json" />
 		<None Remove="JSON\kbnhud.json" />
+		<None Remove="JSON\m0rehud.json" />
 		<None Remove="JSON\rayshud.json" />
 		<None Remove="JSON\zeeshud.json" />
 		<None Remove="log4net.config" />
@@ -62,12 +63,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
 		<PackageReference Include="CountryFlag" Version="2.1.0" />
 		<PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.103" />
 		<PackageReference Include="log4net" Version="2.0.15" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Octokit" Version="6.2.1" />
+		<PackageReference Include="Octokit" Version="7.0.1" />
 		<PackageReference Include="WPFLocalizeExtension" Version="3.10.0" />
 	</ItemGroup>
 

--- a/src/TF2HUD.Editor/JSON/Schema/schema.json
+++ b/src/TF2HUD.Editor/JSON/Schema/schema.json
@@ -156,6 +156,12 @@
                   "type": "string"
                 }
               },
+              "ComboDirectories": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "Restart": {
                 "type": "boolean"
               },

--- a/src/TF2HUD.Editor/JSON/Shared/shared.json
+++ b/src/TF2HUD.Editor/JSON/Shared/shared.json
@@ -69,29 +69,6 @@
     ]
   },
   {
-    "Name": "m0rehud",
-    "Description": "Clean, functional and minimalistic HUD created by m0re.",
-    "Author": "Hypnotize",
-    "Thumbnail": "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-banner.webp",
-    "Links": {
-      "Update": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip", // TODO: Remove
-      "GitHub": "https://github.com/Hypnootize/m0rehud",
-      "TF2Huds": "https://tf2huds.dev/hud/m0re-Hud",
-      "Download": [
-        {
-          "Source": "GitHub",
-          "Link": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip"
-        }
-      ]
-    },
-    "Screenshots": [
-      "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-menu.webp",
-      "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-buff.webp",
-      "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-scoreboard.webp",
-      "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-spectator.webp"
-    ]
-  },
-  {
     "Name": "7HUD",
     "Description": "Originally based off an old yA version. Hope you guys like it. Updates are typically delayed because I'm a full-time student, but I love TF2 and can't live without this HUD anymore, so you can always expect an update at some point. You should grab 4Plug to take full advantage of the customization of this hud.",
     "Author": "sevin",

--- a/src/TF2HUD.Editor/JSON/berryhud.json
+++ b/src/TF2HUD.Editor/JSON/berryhud.json
@@ -16,7 +16,6 @@
     "0 3 4 4"
   ],
   "Links": {
-    "Update": "https://github.com/hexereii/BerryHUD/archive/refs/heads/main.zip",
     "GitHub": "https://github.com/hexereii/BerryHUD",
     "TF2Huds": "https://tf2huds.dev/hud/BerryHUD",
     "Download": [

--- a/src/TF2HUD.Editor/JSON/budhud.json
+++ b/src/TF2HUD.Editor/JSON/budhud.json
@@ -17,7 +17,6 @@
     "4 7 7 7"
   ],
   "Links": {
-    "Update": "https://github.com/rbjaxter/budhud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/rbjaxter/budhud",
     "TF2Huds": "https://tf2huds.dev/hud/budhud",
     "ComfigHuds": "https://comfig.app/huds/page/budhud/",

--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -862,8 +862,8 @@
               },
               "resource/ui/huddemomancharge.res": {
                 "ChargeMeter": {
-                  "xpos": "c-55",
-                  "ypos": "c145"
+                  "xpos": "0",
+                  "ypos": "8"
                 }
               },
               "resource/ui/huddemomanpipes.res": {
@@ -872,32 +872,28 @@
                   "ypos": "c100"
                 },
                 "PipesPresentPanel": {
-                  "xpos": "c-20",
-                  "ypos": "c125"
+                  "xpos": "c147",
+                  "ypos": "r74"
                 }
               },
               "resource/ui/huditemeffectmeter.res": {
                 "HudItemEffectMeter": {
-                  "xpos": "c-55",
-                  "ypos": "c135"
+                  "xpos": "c150",
+                  "ypos": "c108"
                 }
               },
               "resource/ui/huditemeffectmeter_cleaver.res": {
                 "HudItemEffectMeter": {
-                  "ypos": "c145"
+                  "ypos": "c97"
                 }
               },
               "resource/ui/huditemeffectmeter_demoman.res": {
                 "HudItemEffectMeter": {
-                  "xpos": "c140",
+                  "xpos": "c190",
                   "ypos": "r75"
                 },
-                "ItemEffectMeterLabel": {
-                  "visible": "1",
-                  "enabled": "1"
-                },
                 "ItemEffectMeterCount": {
-                  "xpos": "46"
+                  "xpos": "17"
                 },
                 "StreakIcon": {
                   "visible": "0",
@@ -910,13 +906,13 @@
               },
               "resource/ui/huditemeffectmeter_killstreak.res": {
                 "HudItemEffectMeter": {
-                  "xpos": "c200",
+                  "xpos": "c227",
                   "ypos": "r75"
                 }
               },
               "resource/ui/huditemeffectmeter_sodapopper.res": {
                 "HudItemEffectMeter": {
-                  "ypos": "c125"
+                  "ypos": "c86"
                 }
               },
               "resource/ui/hudplayerclass.res": {
@@ -928,7 +924,7 @@
                   "ypos": "r200"
                 },
                 "CarryingWeapon": {
-                  "xpos": "100"
+                  "xpos": "0"
                 }
               },
               "resource/ui/hudplayerhealth.res": {
@@ -978,8 +974,8 @@
               },
               "resource/ui/hudrocketpack.res": {
                 "HudItemEffectMeter": {
-                  "xpos": "c-55",
-                  "ypos": "c115"
+                  "xpos": "c85",
+                  "ypos": "110"
                 }
               },
               "resource/ui/hudspellselection.res": {
@@ -1065,10 +1061,6 @@
                   "xpos": "125",
                   "ypos": "r30"
                 },
-                "ItemEffectMeterLabel": {
-                  "visible": "0",
-                  "enabled": "0"
-                },
                 "ItemEffectMeterCount": {
                   "xpos": "20"
                 },
@@ -1117,13 +1109,13 @@
                 "ChargeLabel": {
                   "ypos": "0",
                   "textAlignment": "east",
-                  "font": "FontBold50",
+                  "font": "FontBold48",
                   "pin_corner_to_sibling": "PIN_TOPLEFT",
                   "pin_to_sibling_corner": "PIN_TOPLEFT"
                 },
                 "ChargeLabelShadow": {
                   "textAlignment": "east",
-                  "font": "FontBold50"
+                  "font": "FontBold48"
                 },
                 "IndividualChargesLabel": {
                   "ypos": "13",
@@ -1219,13 +1211,13 @@
                   "xpos": "9999"
                 },
                 "HealthBG": {
-                  "bgcolor_override": "HudBlack"
+                  "bgcolor_override": "BGBlack"
                 },
                 "PlayerStatusHealthBonusImage": {
                   "xpos": "9999"
                 },
                 "PlayerHealthValue": {
-                  "font": "FontBold50"
+                  "font": "FontBold48"
                 },
                 "PlayerHealthShadow": {
                   "font": "ScanlineShadow"
@@ -1233,7 +1225,7 @@
               },
               "resource/ui/hudammoweapons.res": {
                 "AmmoBG": {
-                  "bgcolor_override": "HudBlack"
+                  "bgcolor_override": "BGBlack"
                 },
                 "AmmoInClipShadow": {
                   "font": "ScanlineShadow"
@@ -1278,10 +1270,10 @@
                   "xpos": "9999"
                 },
                 "PlayerHealthValue": {
-                  "font": "FontBold50"
+                  "font": "FontBold48"
                 },
                 "PlayerHealthShadow": {
-                  "font": "FontBold50"
+                  "font": "FontBold48"
                 }
               },
               "resource/ui/hudammoweapons.res": {
@@ -1289,13 +1281,13 @@
                   "bgcolor_override": "Transparent"
                 },
                 "AmmoInClipShadow": {
-                  "font": "FontBold50"
+                  "font": "FontBold48"
                 },
                 "AmmoInReserveShadow": {
                   "font": "FontBold22"
                 },
                 "AmmoNoClipShadow": {
-                  "font": "FontBold50"
+                  "font": "FontBold48"
                 }
               },
               "scripts/hudanimations_custom.txt": {
@@ -1339,7 +1331,7 @@
               },
               "resource/ui/hudammoweapons.res": {
                 "AmmoBG": {
-                  "bgcolor_override": "HudBlack"
+                  "bgcolor_override": "BGBlack"
                 },
                 "AmmoInClipShadow": {
                   "font": "ScanlineShadow"

--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -40,7 +40,7 @@
     "HUD Colors": [
       {
         "Name": "fh_color_primary",
-        "Label": "Primary Color",
+        "Label": "Theme Color",
         "Type": "ColorPicker",
         "ToolTip": "Primary theme and text color.",
         "Value": "235 226 202 255",
@@ -61,7 +61,7 @@
         "Label": "UberCharge",
         "Type": "ColorPicker",
         "ToolTip": "Color of the UberCharge meter.",
-        "Value": "0 191 121 255",
+        "Value": "0 225 165 255",
         "Restart": true,
         "Pulse": true,
         "Files": {
@@ -484,10 +484,6 @@
               "visible": {
                 "true": "1",
                 "false": "0"
-              },
-              "enabled": {
-                "true": "1",
-                "false": "0"
               }
             }
           }
@@ -522,10 +518,6 @@
               "visible": {
                 "true": "1",
                 "false": "0"
-              },
-              "enabled": {
-                "true": "1",
-                "false": "0"
               }
             }
           }
@@ -541,26 +533,16 @@
           "resource/ui/basechat.res": {
             "HudChat": {
               "ypos": {
-                "true": "r175",
+                "true": "c-55",
                 "false": "15"
               }
             }
           },
           "scripts/hudlayout.res": {
-            "DisguiseStatus": {
+            "BuildingStatusAnchor": {
               "ypos": {
-                "true": "r45",
-                "false": "r160"
-              }
-            },
-            "HudAchievementTracker": {
-              "NormalY": {
-                "true": "15",
-                "false": "310"
-              },
-              "EngineerY": {
-                "true": "15",
-                "false": "310"
+                "true": "0",
+                "false": "c-130"
               }
             }
           }
@@ -652,10 +634,6 @@
               "visible": {
                 "true": "1",
                 "false": "0"
-              },
-              "enabled": {
-                "true": "1",
-                "false": "0"
               }
             }
           }
@@ -665,7 +643,7 @@
         "Name": "fh_min_item_meters",
         "Label": "Minimal Item Meters",
         "Type": "Checkbox",
-        "ToolTip": "Expand the scoreboard to show 32 players.",
+        "ToolTip": "Use a minimal style for the item meters.",
         "Value": "true",
         "Restart": false,
         "Files": {
@@ -706,6 +684,26 @@
                 "false": "c135"
               }
             }
+          },
+          "scripts/hudlayout.res": {
+            "CMainTargetID": {
+              "ypos": {
+                "true": "c50",
+                "false": "c30"
+              }
+            },
+            "CSpectatorTargetID": {
+              "ypos": {
+                "true": "c80",
+                "false": "c60"
+              }
+            },
+            "CSecondaryTargetID": {
+              "ypos": {
+                "true": "c80",
+                "false": "c60"
+              }
+            }
           }
         }
       },
@@ -716,89 +714,21 @@
         "ToolTip": "Toggle Mann vs. Machine currency position.",
         "Value": "false",
         "Files": {
-          "resource/ui/huditemeffectmeter_powerupbottle.res": {
-            "HudItemEffectMeter": {
-              "xpos": {
-                "true": "152",
-                "false": "142"
-              },
-              "wide": {
-                "true": "30",
-                "false": "40"
-              }
-            },
-            "PowerupBG": {
-              "tall": {
-                "true": "15",
-                "false": "30"
-              }
-            },
-            "ItemEffectIcon": {
-              "xpos": {
-                "true": "1",
-                "false": "0"
-              },
-              "ypos": {
-                "true": "2",
-                "false": "3"
-              },
-              "wide": {
-                "true": "12",
-                "false": "25"
-              },
-              "tall": {
-                "true": "12",
-                "false": "25"
-              }
-            },
-            "ItemEffectMeterCount": {
-              "xpos": {
-                "true": "15",
-                "false": "25"
-              },
-              "ypos": {
-                "true": "2",
-                "false": "0"
-              },
-              "tall": {
-                "true": "12",
-                "false": "30"
-              },
-              "font": {
-                "true": "FontBold14",
-                "false": "FontBold22"
-              }
-            }
-          },
           "resource/ui/hudmannvsmachinestatus.res": {
             "InWorldCurrencyPanel": {
               "xpos": {
-                "true": "c-50",
-                "false": "c-245"
+                "true": "c-52",
+                "false": "c-250"
               },
               "ypos": {
-                "true": "c10",
-                "false": "r25"
+                "true": "c5",
+                "false": "r60"
               }
             }
           },
           "resource/ui/mvminworldcurrency.res": {
-            "CurrencyBG": {
-              "visible": {
-                "true": "0",
-                "false": "1"
-              },
-              "enabled": {
-                "true": "0",
-                "false": "1"
-              }
-            },
             "CurrencyLabel": {
               "visible": {
-                "true": "0",
-                "false": "1"
-              },
-              "enabled": {
                 "true": "0",
                 "false": "1"
               }
@@ -816,9 +746,9 @@
               }
             },
             "CurrencyBadShadow": {
-              "visible": {
-                "true": "1",
-                "false": "0"
+              "textAlignment": {
+                "true": "center",
+                "false": "east"
               }
             }
           }

--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -662,6 +662,54 @@
         }
       },
       {
+        "Name": "fh_min_item_meters",
+        "Label": "Minimal Item Meters",
+        "Type": "Checkbox",
+        "ToolTip": "Expand the scoreboard to show 32 players.",
+        "Value": "true",
+        "Restart": false,
+        "Files": {
+          "resource/ui/huditemeffectmeter.res": {
+            "HudItemEffectMeter": {
+              "xpos": {
+                "true": "c150",
+                "false": "c-55"
+              },
+              "ypos": {
+                "true": "c97",
+                "false": "c125"
+              }
+            },
+            "ItemEffectMeter": {
+              "ypos": {
+                "true": "8",
+                "false": "0"
+              },
+              "tall": {
+                "true": "2",
+                "false": "8"
+              }
+            }
+          },
+          "resource/ui/huditemeffectmeter_cleaver.res": {
+            "HudItemEffectMeter": {
+              "ypos": {
+                "true": "c108",
+                "false": "c115"
+              }
+            }
+          },
+          "resource/ui/huditemeffectmeter_sodapopper.res": {
+            "HudItemEffectMeter": {
+              "ypos": {
+                "true": "c86",
+                "false": "c135"
+              }
+            }
+          }
+        }
+      },
+      {
         "Name": "fh_centered_mvm_currency",
         "Label": "Centered MvM Currency",
         "Type": "Checkbox",

--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -860,12 +860,6 @@
                   "ypos": "c100"
                 }
               },
-              "resource/ui/huddemomancharge.res": {
-                "ChargeMeter": {
-                  "xpos": "0",
-                  "ypos": "8"
-                }
-              },
               "resource/ui/huddemomanpipes.res": {
                 "ChargeMeter": {
                   "xpos": "c-55",
@@ -891,17 +885,6 @@
                 "HudItemEffectMeter": {
                   "xpos": "c190",
                   "ypos": "r75"
-                },
-                "ItemEffectMeterCount": {
-                  "xpos": "17"
-                },
-                "StreakIcon": {
-                  "visible": "0",
-                  "enabled": "0"
-                },
-                "StreakIconShadow": {
-                  "visible": "0",
-                  "enabled": "0"
                 }
               },
               "resource/ui/huditemeffectmeter_killstreak.res": {
@@ -993,7 +976,7 @@
                   "ypos": "r135"
                 },
                 "HudDemomanCharge": {
-                  "ypos": "0"
+                  "ypos": "c97"
                 },
                 "CHudAccountPanel": {
                   "xpos": "c-50",
@@ -1004,13 +987,14 @@
                   "ypos": "c54"
                 },
                 "DisguiseStatus": {
-                  "ypos": "r160"
+                  "xpos": "c150",
+                  "ypos": "c97"
                 },
                 "CSpectatorTargetID": {
-                  "ypos": "c50"
+                  "ypos": "c60"
                 },
                 "CSecondaryTargetID": {
-                  "ypos": "c50"
+                  "ypos": "c60"
                 },
                 "HudSpellMenu": {
                   "xpos": "c-210",
@@ -1027,12 +1011,6 @@
                 "DamageAccountValue": {
                   "xpos": "10",
                   "ypos": "r75"
-                }
-              },
-              "resource/ui/huddemomancharge.res": {
-                "ChargeMeter": {
-                  "xpos": "r120",
-                  "ypos": "c105"
                 }
               },
               "resource/ui/huddemomanpipes.res": {
@@ -1060,17 +1038,6 @@
                 "HudItemEffectMeter": {
                   "xpos": "125",
                   "ypos": "r30"
-                },
-                "ItemEffectMeterCount": {
-                  "xpos": "20"
-                },
-                "StreakIcon": {
-                  "visible": "1",
-                  "enabled": "1"
-                },
-                "StreakIconShadow": {
-                  "visible": "1",
-                  "enabled": "1"
                 }
               },
               "resource/ui/huditemeffectmeter_killstreak.res": {
@@ -1109,13 +1076,13 @@
                 "ChargeLabel": {
                   "ypos": "0",
                   "textAlignment": "east",
-                  "font": "FontBold48",
+                  "font": "FontBold50",
                   "pin_corner_to_sibling": "PIN_TOPLEFT",
                   "pin_to_sibling_corner": "PIN_TOPLEFT"
                 },
                 "ChargeLabelShadow": {
                   "textAlignment": "east",
-                  "font": "FontBold48"
+                  "font": "FontBold50"
                 },
                 "IndividualChargesLabel": {
                   "ypos": "13",
@@ -1162,7 +1129,8 @@
                   "ypos": "r65"
                 },
                 "HudDemomanCharge": {
-                  "ypos": "60"
+                  "xpos": "r120",
+                  "ypos": "r75"
                 },
                 "CHudAccountPanel": {
                   "xpos": "r110",
@@ -1217,7 +1185,7 @@
                   "xpos": "9999"
                 },
                 "PlayerHealthValue": {
-                  "font": "FontBold48"
+                  "font": "FontBold50"
                 },
                 "PlayerHealthShadow": {
                   "font": "ScanlineShadow"
@@ -1270,10 +1238,10 @@
                   "xpos": "9999"
                 },
                 "PlayerHealthValue": {
-                  "font": "FontBold48"
+                  "font": "FontBold50"
                 },
                 "PlayerHealthShadow": {
-                  "font": "FontBold48"
+                  "font": "FontBold50"
                 }
               },
               "resource/ui/hudammoweapons.res": {
@@ -1281,13 +1249,13 @@
                   "bgcolor_override": "Transparent"
                 },
                 "AmmoInClipShadow": {
-                  "font": "FontBold48"
+                  "font": "FontBold50"
                 },
                 "AmmoInReserveShadow": {
                   "font": "FontBold22"
                 },
                 "AmmoNoClipShadow": {
-                  "font": "FontBold48"
+                  "font": "FontBold50"
                 }
               },
               "scripts/hudanimations_custom.txt": {

--- a/src/TF2HUD.Editor/JSON/hexhud.json
+++ b/src/TF2HUD.Editor/JSON/hexhud.json
@@ -16,7 +16,6 @@
     "4 3 3"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/hexhud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/hexhud",
     "TF2Huds": "https://tf2huds.dev/hud/HExHUD",
     "ComfigHuds": "https://comfig.app/huds/page/hexhud/",

--- a/src/TF2HUD.Editor/JSON/hud-fixes.json
+++ b/src/TF2HUD.Editor/JSON/hud-fixes.json
@@ -9,7 +9,6 @@
     "0 0 1 1"
   ],
   "Links": {
-    "Update": "https://github.com/CriticalFlaw/TF2HUD.Fixes/archive/refs/heads/complete.zip", // TODO: Remove
     "GitHub": "https://github.com/CriticalFlaw/TF2HUD.Fixes",
     "Discord": "https://discord.gg/hTdtK9vBhE",
     "Download": [

--- a/src/TF2HUD.Editor/JSON/hypnotize-hud.json
+++ b/src/TF2HUD.Editor/JSON/hypnotize-hud.json
@@ -16,7 +16,6 @@
     "3 4 4"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/hypnotizehud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/hypnotizehud",
     "TF2Huds": "https://tf2huds.dev/hud/Hypnotize-Hud",
     "ComfigHuds": "https://comfig.app/huds/page/hypnotizehud/",

--- a/src/TF2HUD.Editor/JSON/kbnhud.json
+++ b/src/TF2HUD.Editor/JSON/kbnhud.json
@@ -29,7 +29,6 @@
   //10-Spy & Engie Color Options
   //Refer to screenshot of this HUD's options for more visual aid, this file is meant to be a guide for newcomers as well as a working piece of code.
   "Links": {
-    "Update": "https://github.com/Jotunn/kbnhud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Jotunn/kbnhud",
     "TF2Huds": "https://tf2huds.dev/hud/KBNHud",
     "ComfigHuds": "https://comfig.app/huds/page/kbnhud/",

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -17,7 +17,6 @@
     "5 3 2 2"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/m0rehud",
     "ComfigHuds": "https://comfig.app/huds/page/m0rehud/",
     "TF2Huds": "https://tf2huds.dev/hud/m0re-Hud",

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -9,7 +9,7 @@
     "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-scoreboard.webp",
     "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-spectator.webp"
   ],
-  "Background": "https://i.imgur.com/cBFURIz.png",
+  "Background": "https://i.imgur.com/vZmMuKh.png",
   "Layout": [
     "0 0 1 1",
     "6 6 1 1",

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -28,7 +28,7 @@
     ]
   },
   "CustomizationsFolder": "customizations",
-  "EnabledFolder": "customizations//_enabled",
+  "EnabledFolder": "",
   "Controls": {
     "Damage": [
       {
@@ -37,43 +37,43 @@
         "Type": "ComboBox",
         "Value": "4",
         "ComboFiles": [
-          "Damage/[Damage Numbers] Big",
-          "Damage/[Damage Numbers] Big Minusless",
-          "Damage/[Damage Numbers] Medium",
-          "Damage/[Damage Numbers] Medium Minusless",
-          "Damage/[Damage Numbers] Small (Default ON)",
-          "Damage/[Damage Numbers] Small Minusless"
+          "Damage\\[Damage Numbers] Big",
+          "Damage\\[Damage Numbers] Big Minusless",
+          "Damage\\[Damage Numbers] Medium",
+          "Damage\\[Damage Numbers] Medium Minusless",
+          "Damage\\[Damage Numbers] Small (Default ON)",
+          "Damage\\[Damage Numbers] Small Minusless"
         ],
         "Options": [
           {
             "Label": "Big",
             "Value": "0",
-            "FileName": "Damage/[Damage Numbers] Big"
+            "FileName": "Damage\\[Damage Numbers] Big"
           },
           {
             "Label": "Big Minusless",
             "Value": "1",
-            "FileName": "Damage/[Damage Numbers] Big Minusless"
+            "FileName": "Damage\\[Damage Numbers] Big Minusless"
           },
           {
             "Label": "Medium",
             "Value": "2",
-            "FileName": "Damage/[Damage Numbers] Medium"
+            "FileName": "Damage\\[Damage Numbers] Medium"
           },
           {
             "Label": "Medium Minusless",
             "Value": "3",
-            "FileName": "Damage/[Damage Numbers] Medium Minusless"
+            "FileName": "Damage\\[Damage Numbers] Medium Minusless"
           },
           {
             "Label": "Small",
             "Value": "4",
-            "FileName": "Damage/[Damage Numbers] Small (Default ON)"
+            "FileName": "Damage\\[Damage Numbers] Small (Default ON)"
           },
           {
             "Label": "Small Minusless",
             "Value": "5",
-            "FileName": "Damage/[Damage Numbers] Small Minusless"
+            "FileName": "Damage\\[Damage Numbers] Small Minusless"
           }
         ]
       },
@@ -83,31 +83,31 @@
         "Type": "ComboBox",
         "Value": "3",
         "ComboFiles": [
-          "Damage/[Last Damage Done] Health Cross",
-          "Damage/[Last Damage Done] Minmode",
-          "Damage/[Last Damage Done] Normal",
-          "Damage/[Last Damage Done] OFF (Default ON)"
+          "Damage\\[Last Damage Done] Health Cross",
+          "Damage\\[Last Damage Done] Minmode",
+          "Damage\\[Last Damage Done] Normal",
+          "Damage\\[Last Damage Done] OFF (Default ON)"
         ],
         "Options": [
           {
             "Label": "Health Cross",
             "Value": "0",
-            "FileName": "Damage/[Last Damage Done] Health Cross"
+            "FileName": "Damage\\[Last Damage Done] Health Cross"
           },
           {
             "Label": "Minmode",
             "Value": "1",
-            "FileName": "Damage/[Last Damage Done] Minmode"
+            "FileName": "Damage\\[Last Damage Done] Minmode"
           },
           {
             "Label": "Normal",
             "Value": "2",
-            "FileName": "Damage/[Last Damage Done] Normal"
+            "FileName": "Damage\\[Last Damage Done] Normal"
           },
           {
             "Label": "OFF",
             "Value": "3",
-            "FileName": "Damage/[Last Damage Done] OFF (Default ON)"
+            "FileName": "Damage\\[Last Damage Done] OFF (Default ON)"
           }
         ]
       },
@@ -117,133 +117,133 @@
         "Type": "ComboBox",
         "Value": "15",
         "ComboFiles": [
-          "Fonts/[Font] Alternate Gothic",
-          "Fonts/[Font] Avenir",
-          "Fonts/[Font] Catamaran",
-          "Fonts/[Font] Cerbetica",
-          "Fonts/[Font] Days",
-          "Fonts/[Font] Handel Gothic",
-          "Fonts/[Font] Lato",
-          "Fonts/[Font] Maven Pro",
-          "Fonts/[Font] Neutra",
-          "Fonts/[Font] Noto",
-          "Fonts/[Font] Product",
-          "Fonts/[Font] Product Bold",
-          "Fonts/[Font] Renogare",
-          "Fonts/[Font] Roboto",
-          "Fonts/[Font] Rubik",
-          "Fonts/[Font] Surface (Default ON)",
-          "Fonts/[Font] Surface Bold",
-          "Fonts/[Font] Surface Sharpened",
-          "Fonts/[Font] TF2",
-          "Fonts/[Font] TF2 Bold",
-          "Fonts/[Font] Ubuntu"
+          "Fonts\\[Font] Alternate Gothic",
+          "Fonts\\[Font] Avenir",
+          "Fonts\\[Font] Catamaran",
+          "Fonts\\[Font] Cerbetica",
+          "Fonts\\[Font] Days",
+          "Fonts\\[Font] Handel Gothic",
+          "Fonts\\[Font] Lato",
+          "Fonts\\[Font] Maven Pro",
+          "Fonts\\[Font] Neutra",
+          "Fonts\\[Font] Noto",
+          "Fonts\\[Font] Product",
+          "Fonts\\[Font] Product Bold",
+          "Fonts\\[Font] Renogare",
+          "Fonts\\[Font] Roboto",
+          "Fonts\\[Font] Rubik",
+          "Fonts\\[Font] Surface (Default ON)",
+          "Fonts\\[Font] Surface Bold",
+          "Fonts\\[Font] Surface Sharpened",
+          "Fonts\\[Font] TF2",
+          "Fonts\\[Font] TF2 Bold",
+          "Fonts\\[Font] Ubuntu"
         ],
         "Options": [
           {
             "Label": "Alternate Gothic",
             "Value": "0",
-            "FileName": "Fonts/[Font] Alternate Gothic"
+            "FileName": "Fonts\\[Font] Alternate Gothic"
           },
           {
             "Label": "Avenir",
             "Value": "1",
-            "FileName": "Fonts/[Font] Avenir"
+            "FileName": "Fonts\\[Font] Avenir"
           },
           {
             "Label": "Catamaran",
             "Value": "2",
-            "FileName": "Fonts/[Font] Catamaran"
+            "FileName": "Fonts\\[Font] Catamaran"
           },
           {
             "Label": "Cerbetica",
             "Value": "3",
-            "FileName": "Fonts/[Font] Cerbetica"
+            "FileName": "Fonts\\[Font] Cerbetica"
           },
           {
             "Label": "Days",
             "Value": "4",
-            "FileName": "Fonts/[Font] Days"
+            "FileName": "Fonts\\[Font] Days"
           },
           {
             "Label": "Handel Gothic",
             "Value": "5",
-            "FileName": "Fonts/[Font] Handel Gothic"
+            "FileName": "Fonts\\[Font] Handel Gothic"
           },
           {
             "Label": "Lato",
             "Value": "6",
-            "FileName": "Fonts/[Font] Lato"
+            "FileName": "Fonts\\[Font] Lato"
           },
           {
             "Label": "Maven Pro",
             "Value": "7",
-            "FileName": "Fonts/[Font] Maven Pro"
+            "FileName": "Fonts\\[Font] Maven Pro"
           },
           {
             "Label": "Neutra",
             "Value": "8",
-            "FileName": "Fonts/[Font] Neutra"
+            "FileName": "Fonts\\[Font] Neutra"
           },
           {
             "Label": "Noto",
             "Value": "9",
-            "FileName": "Fonts/[Font] Noto"
+            "FileName": "Fonts\\[Font] Noto"
           },
           {
             "Label": "Product",
             "Value": "10",
-            "FileName": "Fonts/[Font] Product"
+            "FileName": "Fonts\\[Font] Product"
           },
           {
             "Label": "Product Bold",
             "Value": "11",
-            "FileName": "Fonts/[Font] Product Bold"
+            "FileName": "Fonts\\[Font] Product Bold"
           },
           {
             "Label": "Renogare",
             "Value": "12",
-            "FileName": "Fonts/[Font] Renogare"
+            "FileName": "Fonts\\[Font] Renogare"
           },
           {
             "Label": "Roboto",
             "Value": "13",
-            "FileName": "Fonts/[Font] Roboto"
+            "FileName": "Fonts\\[Font] Roboto"
           },
           {
             "Label": "Rubik",
             "Value": "14",
-            "FileName": "Fonts/[Font] Rubik"
+            "FileName": "Fonts\\[Font] Rubik"
           },
           {
             "Label": "Surface",
             "Value": "15",
-            "FileName": "Fonts/[Font] Surface (Default ON)"
+            "FileName": "Fonts\\[Font] Surface (Default ON)"
           },
           {
             "Label": "Surface Bold",
             "Value": "16",
-            "FileName": "Fonts/[Font] Surface Bold"
+            "FileName": "Fonts\\[Font] Surface Bold"
           },
           {
             "Label": "Surface Sharpened",
             "Value": "17",
-            "FileName": "Fonts/[Font] Surface Sharpened"
+            "FileName": "Fonts\\[Font] Surface Sharpened"
           },
           {
             "Label": "TF2",
             "Value": "18",
-            "FileName": "Fonts/[Font] TF2"
+            "FileName": "Fonts\\[Font] TF2"
           },
           {
             "Label": "TF2 Bold",
             "Value": "19",
-            "FileName": "Fonts/[Font] TF2 Bold"
+            "FileName": "Fonts\\[Font] TF2 Bold"
           },
           {
             "Label": "Ubuntu",
             "Value": "20",
-            "FileName": "Fonts/[Font] Ubuntu"
+            "FileName": "Fonts\\[Font] Ubuntu"
           }
         ]
       },
@@ -253,19 +253,19 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Heads Counter/[Counter] Bottom Right (Default ON)",
-          "Heads Counter/[Counter] Under Ammo"
+          "Heads Counter\\[Counter] Bottom Right (Default ON)",
+          "Heads Counter\\[Counter] Under Ammo"
         ],
         "Options": [
           {
             "Label": "Bottom Right",
             "Value": "0",
-            "FileName": "Heads Counter/[Counter] Bottom Right (Default ON)"
+            "FileName": "Heads Counter\\[Counter] Bottom Right (Default ON)"
           },
           {
             "Label": "Under Ammo",
             "Value": "1",
-            "FileName": "Heads Counter/[Counter] Under Ammo"
+            "FileName": "Heads Counter\\[Counter] Under Ammo"
           }
         ]
       },
@@ -274,7 +274,7 @@
         "Label": "Flashing Ammo Colors",
         "Type": "Checkbox",
         "Value": "false",
-        "FileName": "Health Ammo Uber Animation Style/[Ammo Style] Flashing Colors"
+        "FileName": "Health Ammo Uber Animation Style\\[Ammo Style] Flashing Colors"
       },
       {
         "Name": "mh_general_style",
@@ -282,19 +282,19 @@
         "Type": "ComboBox",
         "Value": "1",
         "ComboFiles": [
-          "Health Ammo Uber Animation Style/[General Style] Colored Number",
-          "Health Ammo Uber Animation Style/[General Style] Colored Shadow (Default ON)"
+          "Health Ammo Uber Animation Style\\[General Style] Colored Number",
+          "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
         ],
         "Options": [
           {
             "Label": "Colored Nunmber",
             "Value": "0",
-            "FileName": "Health Ammo Uber Animation Style/[General Style] Colored Number"
+            "FileName": "Health Ammo Uber Animation Style\\[General Style] Colored Number"
           },
           {
             "Label": "Colored Shadow",
             "Value": "1",
-            "FileName": "Health Ammo Uber Animation Style/[General Style] Colored Shadow (Default ON)"
+            "FileName": "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
           }
         ]
       },
@@ -304,55 +304,55 @@
         "Type": "ComboBox",
         "Value": "2",
         "ComboFiles": [
-          "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Big Font",
-          "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Small Font",
-          "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Big Font (Default ON)",
-          "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Small Font",
-          "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Big Font",
-          "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Small Font",
-          "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Big Font",
-          "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Small Font"
+          "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)",
+          "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Small Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Big Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Small Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Big Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Small Font"
         ],
         "Options": [
           {
             "Label": "Buff Rectangle, Big Font",
             "Value": "0",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Big Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font"
           },
           {
             "Label": "Buff Rectangle, Small Font",
             "Value": "1",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Small Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font"
           },
           {
             "Label": "Buff Cross, Big Font",
             "Value": "2",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Big Font (Default ON)"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)"
           },
           {
             "Label": "Buff Cross, Small Font",
             "Value": "3",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Small Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Small Font"
           },
           {
             "Label": "No Cross, Big Font",
             "Value": "4",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Big Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Big Font"
           },
           {
             "Label": "No Cross, Small Font",
             "Value": "5",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Small Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Small Font"
           },
           {
             "Label": "Static Rectangle, Big Font",
             "Value": "6",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Big Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Big Font"
           },
           {
             "Label": "Static Rectangle, Small Font",
             "Value": "7",
-            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Small Font"
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Small Font"
           }
         ]
       },
@@ -362,43 +362,43 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Big Font (Default ON)",
-          "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Small Font",
-          "Health Ammo Uber Style/[Health] Health Cross",
-          "Health Ammo Uber Style/[Health] Health Cross With Team Colored Border",
-          "Health Ammo Uber Style/[Ubercharge] Old m0rehud Style",
-          "Health Ammo Uber Style/[Ubercharge] Uber Meter & Small Label Off"
+          "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)",
+          "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font",
+          "Health Ammo Uber Style\\[Health] Health Cross",
+          "Health Ammo Uber Style\\[Health] Health Cross With Team Colored Border",
+          "Health Ammo Uber Style\\[Ubercharge] Old m0rehud Style",
+          "Health Ammo Uber Style\\[Ubercharge] Uber Meter & Small Label Off"
         ],
         "Options": [
           {
             "Label": "Default Style, Big Font",
             "Value": "0",
-            "FileName": "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Big Font (Default ON)"
+            "FileName": "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)"
           },
           {
             "Label": "Default Style, Small Font",
             "Value": "1",
-            "FileName": "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Small Font"
+            "FileName": "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font"
           },
           {
             "Label": "Health Cross",
             "Value": "2",
-            "FileName": "Health Ammo Uber Style/[Health] Health Cross"
+            "FileName": "Health Ammo Uber Style\\[Health] Health Cross"
           },
           {
             "Label": "Health Cross w/Team Colors",
             "Value": "3",
-            "FileName": "Health Ammo Uber Style/[Health] Health Cross With Team Colored Border"
+            "FileName": "Health Ammo Uber Style\\[Health] Health Cross With Team Colored Border"
           },
           {
             "Label": "Old m0rehud Style",
             "Value": "4",
-            "FileName": "Health Ammo Uber Style/[Ubercharge] Old m0rehud Style"
+            "FileName": "Health Ammo Uber Style\\[Ubercharge] Old m0rehud Style"
           },
           {
             "Label": "Uber Meter & Small Label Off",
             "Value": "5",
-            "FileName": "Health Ammo Uber Style/[Ubercharge] Uber Meter & Small Label Off"
+            "FileName": "Health Ammo Uber Style\\[Ubercharge] Uber Meter & Small Label Off"
           }
         ]
       },
@@ -408,25 +408,25 @@
         "Type": "ComboBox",
         "Value": "2",
         "ComboFiles": [
-          "Killstreak/[Killstreak] Counter Bottom Left",
-          "Killstreak/[Killstreak] Counter Close To The Killfeed",
-          "Killstreak/[Killstreak] Counter Disabled (Default ON)"
+          "Killstreak\\[Killstreak] Counter Bottom Left",
+          "Killstreak\\[Killstreak] Counter Close To The Killfeed",
+          "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
         ],
         "Options": [
           {
             "Label": "Bottom Left",
             "Value": "0",
-            "FileName": "Killstreak/[Killstreak] Counter Bottom Left"
+            "FileName": "Killstreak\\[Killstreak] Counter Bottom Left"
           },
           {
             "Label": "Close to Killfeed",
             "Value": "1",
-            "FileName": "Killstreak/[Killstreak] Counter Close To The Killfeed"
+            "FileName": "Killstreak\\[Killstreak] Counter Close To The Killfeed"
           },
           {
             "Label": "Disabled",
             "Value": "2",
-            "FileName": "Killstreak/[Killstreak] Counter Disabled (Default ON)"
+            "FileName": "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
           }
         ]
       },
@@ -450,19 +450,19 @@
         "Type": "ComboBox",
         "Value": "1",
         "ComboFiles": [
-          "Scoreboards/[Scoreboard] Fosters",
-          "Scoreboards/[Scoreboard] m0re (Default ON)"
+          "Scoreboards\\[Scoreboard] Fosters",
+          "Scoreboards\\[Scoreboard] m0re (Default ON)"
         ],
         "Options": [
           {
             "Label": "Fosters",
             "Value": "0",
-            "FileName": "Scoreboards/[Scoreboard] Fosters"
+            "FileName": "Scoreboards\\[Scoreboard] Fosters"
           },
           {
             "Label": "m0re",
             "Value": "1",
-            "FileName": "Scoreboards/[Scoreboard] m0re (Default ON)"
+            "FileName": "Scoreboards\\[Scoreboard] m0re (Default ON)"
           }
         ]
       },
@@ -472,61 +472,61 @@
         "Type": "ComboBox",
         "Value": "3",
         "ComboFiles": [
-          "SourceSchemes/[SourceScheme] Blue",
-          "SourceSchemes/[SourceScheme] Cyan",
-          "SourceSchemes/[SourceScheme] Fuchsia",
-          "SourceSchemes/[SourceScheme] Green",
-          "SourceSchemes/[SourceScheme] Orange",
-          "SourceSchemes/[SourceScheme] Pink",
-          "SourceSchemes/[SourceScheme] Purple",
-          "SourceSchemes/[SourceScheme] Teal",
-          "SourceSchemes/[SourceScheme] Yellow"
+          "SourceSchemes\\[SourceScheme] Blue",
+          "SourceSchemes\\[SourceScheme] Cyan",
+          "SourceSchemes\\[SourceScheme] Fuchsia",
+          "SourceSchemes\\[SourceScheme] Green",
+          "SourceSchemes\\[SourceScheme] Orange",
+          "SourceSchemes\\[SourceScheme] Pink",
+          "SourceSchemes\\[SourceScheme] Purple",
+          "SourceSchemes\\[SourceScheme] Teal",
+          "SourceSchemes\\[SourceScheme] Yellow"
         ],
         "Options": [
           {
             "Label": "Blue",
             "Value": "0",
-            "FileName": "SourceSchemes/[SourceScheme] Blue"
+            "FileName": "SourceSchemes\\[SourceScheme] Blue"
           },
           {
             "Label": "Cyan",
             "Value": "1",
-            "FileName": "SourceSchemes/[SourceScheme] Cyan"
+            "FileName": "SourceSchemes\\[SourceScheme] Cyan"
           },
           {
             "Label": "Fuchsia",
             "Value": "2",
-            "FileName": "SourceSchemes/[SourceScheme] Fuchsia"
+            "FileName": "SourceSchemes\\[SourceScheme] Fuchsia"
           },
           {
             "Label": "Green",
             "Value": "3",
-            "FileName": "SourceSchemes/[SourceScheme] Green"
+            "FileName": "SourceSchemes\\[SourceScheme] Green"
           },
           {
             "Label": "Orange",
             "Value": "4",
-            "FileName": "SourceSchemes/[SourceScheme] Orange"
+            "FileName": "SourceSchemes\\[SourceScheme] Orange"
           },
           {
             "Label": "Pink",
             "Value": "5",
-            "FileName": "SourceSchemes/[SourceScheme] Pink"
+            "FileName": "SourceSchemes\\[SourceScheme] Pink"
           },
           {
             "Label": "Purple",
             "Value": "6",
-            "FileName": "SourceSchemes/[SourceScheme] Purple"
+            "FileName": "SourceSchemes\\[SourceScheme] Purple"
           },
           {
             "Label": "Teal",
             "Value": "7",
-            "FileName": "SourceSchemes/[SourceScheme] Teal"
+            "FileName": "SourceSchemes\\[SourceScheme] Teal"
           },
           {
             "Label": "Yellow",
             "Value": "8",
-            "FileName": "SourceSchemes/[SourceScheme] Yellow"
+            "FileName": "SourceSchemes\\[SourceScheme] Yellow"
           }
         ]
       },
@@ -536,19 +536,19 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Spectator/[SpectatorHUD] Leftside and Right Side (Default ON)",
-          "Spectator/[SpectatorHUD] Leftside Only"
+          "Spectator\\[SpectatorHUD] Leftside and Right Side (Default ON)",
+          "Spectator\\[SpectatorHUD] Leftside Only"
         ],
         "Options": [
           {
             "Label": "Left and Right Side",
             "Value": "0",
-            "FileName": "Spectator/[SpectatorHUD] Leftside and Right Side (Default ON)"
+            "FileName": "Spectator\\[SpectatorHUD] Leftside and Right Side (Default ON)"
           },
           {
             "Label": "Left Side Only",
             "Value": "1",
-            "FileName": "Spectator/[SpectatorHUD] Leftside Only"
+            "FileName": "Spectator\\[SpectatorHUD] Leftside Only"
           }
         ]
       },
@@ -558,25 +558,25 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Speedometer/[Speed] Speedometer OFF (Default ON)",
-          "Speedometer/[Speed] Speedometer ON - Absolute Speed",
-          "Speedometer/[Speed] Speedometer ON - Horizontal Speed"
+          "Speedometer\\[Speed] Speedometer OFF (Default ON)",
+          "Speedometer\\[Speed] Speedometer ON - Absolute Speed",
+          "Speedometer\\[Speed] Speedometer ON - Horizontal Speed"
         ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "FileName": "Speedometer/[Speed] Speedometer OFF (Default ON)"
+            "FileName": "Speedometer\\[Speed] Speedometer OFF (Default ON)"
           },
           {
             "Label": "ON - Absolute Speed",
             "Value": "1",
-            "FileName": "Speedometer/[Speed] Speedometer ON - Absolute Speed"
+            "FileName": "Speedometer\\[Speed] Speedometer ON - Absolute Speed"
           },
           {
             "Label": "ON - Horizontal Speed",
             "Value": "2",
-            "FileName": "Speedometer/[Speed] Speedometer ON - Horizontal Speed"
+            "FileName": "Speedometer\\[Speed] Speedometer ON - Horizontal Speed"
           }
         ]
       },
@@ -586,19 +586,19 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Spy Disguise/[Disguise] Spy Disguise Image OFF (Default ON)",
-          "Spy Disguise/[Disguise] Spy Disguise Image ON"
+          "Spy Disguise\\[Disguise] Spy Disguise Image OFF (Default ON)",
+          "Spy Disguise\\[Disguise] Spy Disguise Image ON"
         ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "FileName": "Spy Disguise/[Disguise] Spy Disguise Image OFF (Default ON)"
+            "FileName": "Spy Disguise\\[Disguise] Spy Disguise Image OFF (Default ON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "FileName": "Spy Disguise/[Disguise] Spy Disguise Image ON"
+            "FileName": "Spy Disguise\\[Disguise] Spy Disguise Image ON"
           }
         ]
       },
@@ -608,19 +608,19 @@
         "Type": "ComboBox",
         "Value": "1",
         "ComboFiles": [
-          "TargetID/[TargetID] Health Cross",
-          "TargetID/[TargetID] Health Numbers (Default ON)"
+          "TargetID\\[TargetID] Health Cross",
+          "TargetID\\[TargetID] Health Numbers (Default ON)"
         ],
         "Options": [
           {
             "Label": "Health Cross",
             "Value": "0",
-            "FileName": "TargetID/[TargetID] Health Cross"
+            "FileName": "TargetID\\[TargetID] Health Cross"
           },
           {
             "Label": "Health Numbers",
             "Value": "1",
-            "FileName": "TargetID/[TargetID] Health Numbers (Default ON)"
+            "FileName": "TargetID\\[TargetID] Health Numbers (Default ON)"
           }
         ]
       },
@@ -630,67 +630,67 @@
         "Type": "ComboBox",
         "Value": "3",
         "ComboFiles": [
-          "Themes/[Theme] Blue",
-          "Themes/[Theme] Cyan",
-          "Themes/[Theme] Green",
-          "Themes/[Theme] Green & Fuchsia (Default ON)",
-          "Themes/[Theme] Orange",
-          "Themes/[Theme] Pink",
-          "Themes/[Theme] Purple",
-          "Themes/[Theme] Teal",
-          "Themes/[Theme] White",
-          "Themes/[Theme] Yellow"
+          "Themes\\[Theme] Blue",
+          "Themes\\[Theme] Cyan",
+          "Themes\\[Theme] Green",
+          "Themes\\[Theme] Green & Fuchsia (Default ON)",
+          "Themes\\[Theme] Orange",
+          "Themes\\[Theme] Pink",
+          "Themes\\[Theme] Purple",
+          "Themes\\[Theme] Teal",
+          "Themes\\[Theme] White",
+          "Themes\\[Theme] Yellow"
         ],
         "Options": [
           {
             "Label": "Blue",
             "Value": "0",
-            "FileName": "Themes/[Theme] Blue"
+            "FileName": "Themes\\[Theme] Blue"
           },
           {
             "Label": "Cyan",
             "Value": "1",
-            "FileName": "Themes/[Theme] Cyan"
+            "FileName": "Themes\\[Theme] Cyan"
           },
           {
             "Label": "Green",
             "Value": "2",
-            "FileName": "Themes/[Theme] Green"
+            "FileName": "Themes\\[Theme] Green"
           },
           {
             "Label": "Green & Fuchsia",
             "Value": "3",
-            "FileName": "Themes/[Theme] Green & Fuchsia (Default ON)"
+            "FileName": "Themes\\[Theme] Green & Fuchsia (Default ON)"
           },
           {
             "Label": "Orange",
             "Value": "4",
-            "FileName": "Themes/[Theme] Orange"
+            "FileName": "Themes\\[Theme] Orange"
           },
           {
             "Label": "Pink",
             "Value": "5",
-            "FileName": "Themes/[Theme] Pink"
+            "FileName": "Themes\\[Theme] Pink"
           },
           {
             "Label": "Purple",
             "Value": "6",
-            "FileName": "Themes/[Theme] Purple"
+            "FileName": "Themes\\[Theme] Purple"
           },
           {
             "Label": "Teal",
             "Value": "7",
-            "FileName": "Themes/[Theme] Teal"
+            "FileName": "Themes\\[Theme] Teal"
           },
           {
             "Label": "White",
             "Value": "8",
-            "FileName": "Themes/[Theme] White"
+            "FileName": "Themes\\[Theme] White"
           },
           {
             "Label": "Yellow",
             "Value": "9",
-            "FileName": "Themes/[Theme] Yellow"
+            "FileName": "Themes\\[Theme] Yellow"
           }
         ]
       },
@@ -700,31 +700,31 @@
         "Type": "ComboBox",
         "Value": "2",
         "ComboFiles": [
-          "Timers & Match Status/[MatchStatus] HealthBar Big",
-          "Timers & Match Status/[MatchStatus] HealthBar Small",
-          "Timers & Match Status/[MatchStatus] HealthBar Static (DefaultON)",
-          "Timers & Match Status/[MatchStatus] Names ON"
+          "Timers & Match Status\\[MatchStatus] HealthBar Big",
+          "Timers & Match Status\\[MatchStatus] HealthBar Small",
+          "Timers & Match Status\\[MatchStatus] HealthBar Static (DefaultON)",
+          "Timers & Match Status\\[MatchStatus] Names ON"
         ],
         "Options": [
           {
             "Label": "Health Bar Big",
             "Value": "0",
-            "FileName": "Timers & Match Status/[MatchStatus] HealthBar Big"
+            "FileName": "Timers & Match Status\\[MatchStatus] HealthBar Big"
           },
           {
             "Label": "Health Bar Small",
             "Value": "1",
-            "FileName": "Timers & Match Status/[MatchStatus] HealthBar Small"
+            "FileName": "Timers & Match Status\\[MatchStatus] HealthBar Small"
           },
           {
             "Label": "Health Bar Static",
             "Value": "2",
-            "FileName": "Timers & Match Status/[MatchStatus] HealthBar Static (DefaultON)"
+            "FileName": "Timers & Match Status\\[MatchStatus] HealthBar Static (DefaultON)"
           },
           {
             "Label": "Names ON",
             "Value": "3",
-            "FileName": "Timers & Match Status/[MatchStatus] Names ON"
+            "FileName": "Timers & Match Status\\[MatchStatus] Names ON"
           }
         ]
       },
@@ -734,19 +734,19 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Timers & Match Status/[Timer] Background OFF (DefaultON)",
-          "Timers & Match Status/[Timer] Background ON"
+          "Timers & Match Status\\[Timer] Background OFF (DefaultON)",
+          "Timers & Match Status\\[Timer] Background ON"
         ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "FileName": "Timers & Match Status/[Timer] Background OFF (DefaultON)"
+            "FileName": "Timers & Match Status\\[Timer] Background OFF (DefaultON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "FileName": "Timers & Match Status/[Timer] Background ON"
+            "FileName": "Timers & Match Status\\[Timer] Background ON"
           }
         ]
       },
@@ -756,19 +756,19 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels OFF (Default ON)",
-          "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels ON"
+          "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels OFF (Default ON)",
+          "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels ON"
         ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "FileName": "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels OFF (Default ON)"
+            "FileName": "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels OFF (Default ON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "FileName": "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels ON"
+            "FileName": "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels ON"
           }
         ]
       },
@@ -778,19 +778,19 @@
         "Type": "ComboBox",
         "Value": "0",
         "ComboFiles": [
-          "Uber Counter/[Counter] Uber Counter OFF (Default ON)",
-          "Uber Counter/[Counter] Uber Counter ON"
+          "Uber Counter\\[Counter] Uber Counter OFF (Default ON)",
+          "Uber Counter\\[Counter] Uber Counter ON"
         ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "FileName": "Uber Counter/[Counter] Uber Counter OFF (Default ON)"
+            "FileName": "Uber Counter\\[Counter] Uber Counter OFF (Default ON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "FileName": "Uber Counter/[Counter] Uber Counter ON"
+            "FileName": "Uber Counter\\[Counter] Uber Counter ON"
           }
         ]
       }

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -1,0 +1,1000 @@
+{
+  "$schema": "https://raw.githubusercontent.com/CriticalFlaw/TF2HUD.Editor/master/src/TF2HUD.Editor/JSON/Schema/schema.json",
+  "Author": "m0re, Hypnotize",
+  "Description": "Clean, functional and minimalistic HUD created by m0re.",
+  "Thumbnail": "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-banner.webp",
+  "Screenshots": [
+    "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-menu.webp",
+    "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-buff.webp",
+    "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-scoreboard.webp",
+    "https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/m0rehud/m0rehud-spectator.webp"
+  ],
+  "Background": "https://i.imgur.com/cBFURIz.png",
+  "Layout": [
+    "0 0 0 0",
+    "0 0 0 0",
+    "0 0 0 0"
+  ],
+  "Links": {
+    "Update": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip", // TODO: Remove
+    "GitHub": "https://github.com/Hypnootize/m0rehud",
+    "ComfigHuds": "https://comfig.app/huds/page/m0rehud/",
+    "TF2Huds": "https://tf2huds.dev/hud/m0re-Hud",
+    "Download": [
+      {
+        "Source": "GitHub",
+        "Link": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip"
+      }
+    ]
+  },
+  "CustomizationsFolder": "customizations",
+  "EnabledFolder": "",
+  "Controls": {
+    "Damage": [
+      {
+        "Name": "mh_damage_numbers",
+        "Label": "Damage Numbers",
+        "Type": "ComboBox",
+        "Value": "4",
+        "Options": [
+          {
+            "Label": "Big",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Big Minusless",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Medium",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Medium Minusless",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Small",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Small Minusless",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_damage_done",
+        "Label": "Last Damage Done",
+        "Type": "ComboBox",
+        "Value": "3",
+        "Options": [
+          {
+            "Label": "Health Cross",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Minmode",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Normal",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Off",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_font",
+        "Label": "Font",
+        "Type": "ComboBox",
+        "Value": "15",
+        "Options": [
+          {
+            "Label": "Alternate Gothic",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Avenir",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Catamaran",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Cerbetica",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Days",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Handel Gothic",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Lato",
+            "Value": "6",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Maven Pro",
+            "Value": "7",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Neutra",
+            "Value": "8",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Noto",
+            "Value": "9",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Product",
+            "Value": "10",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Product Bold",
+            "Value": "11",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Renogare",
+            "Value": "12",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Roboto",
+            "Value": "13",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Rubik",
+            "Value": "14",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Surface",
+            "Value": "15",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Surface Bold",
+            "Value": "16",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Surface Sharpened",
+            "Value": "17",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "TF2",
+            "Value": "18",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "TF2 Bold",
+            "Value": "19",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Ubuntu",
+            "Value": "20",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_damage_numbers",
+        "Label": "Damage Numbers",
+        "Type": "ComboBox",
+        "Value": "4",
+        "Options": [
+          {
+            "Label": "Big",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Big Minusless",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Medium",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Medium Minusless",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Small",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Small Minusless",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_counter",
+        "Label": "Head Counter",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "Bottom Right",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Under Ammo",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_ammo_style",
+        "Label": "Flashing Ammo Colors",
+        "Type": "Checkbox",
+        "Value": "false",
+        "Files": {
+          "scripts/hudanimations_hitmarker.txt": {
+            "uncomment": [
+              "StopEvent HitMarker",
+              "RunEvent HitMarker"
+            ]
+          }
+        }
+      },
+      {
+        "Name": "mh_general_style",
+        "Label": "General Style",
+        "Type": "ComboBox",
+        "Value": "1",
+        "Options": [
+          {
+            "Label": "Colored Nunmber",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Colored Shadow",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_health_buff",
+        "Label": "Health Buff",
+        "Type": "ComboBox",
+        "Value": "2",
+        "Options": [
+          {
+            "Label": "Buff Rectangle, Big Font",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Buff Rectangle, Small Font",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Buff Cross, Big Font",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Buff Cross, Small Font",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "No Cross, Big Font",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "No Cross, Small Font",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Static Rectangle, Big Font",
+            "Value": "6",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Static Rectangle, Small Font",
+            "Value": "7",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_ammo_uber_style",
+        "Label": "Health, Ammo, Uber",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "Default Style, Big Font",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Default Style, Small Font",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Health Cross",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Health Cross w/Team Colors",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Old m0rehud Style",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Uber Meter & Small Label Off",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_ammo_uber_style",
+        "Label": "Killstreak",
+        "Type": "ComboBox",
+        "Value": "2",
+        "Options": [
+          {
+            "Label": "Bottom Left",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Close to Killfeed",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Disabled",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_minmode",
+        "Label": "Toggle Minmode",
+        "Type": "Checkbox",
+        "Value": "false",
+        "Files": {
+          "scripts/hudanimations_hitmarker.txt": {
+            "uncomment": [
+              "StopEvent HitMarker",
+              "RunEvent HitMarker"
+            ]
+          }
+        }
+      },
+      {
+        "Name": "mh_scoreboard",
+        "Label": "Killstreak",
+        "Type": "ComboBox",
+        "Value": "1",
+        "Options": [
+          {
+            "Label": "Fosters",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "m0re",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_source_scheme",
+        "Label": "Source Scheme",
+        "Type": "ComboBox",
+        "Value": "3",
+        "Options": [
+          {
+            "Label": "Blue",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Cyan",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Fuchsia",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Green",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Orange",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Pink",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Purple",
+            "Value": "6",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Teal",
+            "Value": "7",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Yellow",
+            "Value": "8",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_source_scheme",
+        "Label": "Spectator",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "Left and Right Side",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Left Side Only",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_speedometer",
+        "Label": "Speedometer",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "OFF",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "ON - Absolute Speed",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "ON - Horizontal Speed",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_spy_disguise",
+        "Label": "Spy Disguise Image",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "OFF",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "ON",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_targetId",
+        "Label": "TargetId",
+        "Type": "ComboBox",
+        "Value": "1",
+        "Options": [
+          {
+            "Label": "Health Cross",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Health Numbers",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_themes",
+        "Label": "Themes",
+        "Type": "ComboBox",
+        "Value": "3",
+        "Options": [
+          {
+            "Label": "Blue",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Cyan",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Green",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Green & Fuchsia",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Orange",
+            "Value": "4",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Pink",
+            "Value": "5",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Purple",
+            "Value": "6",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Teal",
+            "Value": "7",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Yellow",
+            "Value": "8",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_match_status",
+        "Label": "Match Status",
+        "Type": "ComboBox",
+        "Value": "2",
+        "Options": [
+          {
+            "Label": "Health Bar Big",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "Health Bar Small",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Health Bar Static",
+            "Value": "2",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          },
+          {
+            "Label": "Names ON",
+            "Value": "3",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_timer",
+        "Label": "Timer Background",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "OFF",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "ON",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_transparent_viewmodels",
+        "Label": "Transparent Viewmodels",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "OFF",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "ON",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      },
+      {
+        "Name": "mh_uber_counters",
+        "Label": "Uber Counters",
+        "Type": "ComboBox",
+        "Value": "0",
+        "Options": [
+          {
+            "Label": "OFF",
+            "Value": "0",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_4x3/",
+              "NewName": "^customizations/#resolutions/4x3/"
+            }
+          },
+          {
+            "Label": "ON",
+            "Value": "1",
+            "RenameFile": {
+              "OldName": "^customizations/#resolutions/_16x9/",
+              "NewName": "^customizations/#resolutions/16x9/"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -28,7 +28,7 @@
     ]
   },
   "CustomizationsFolder": "customizations",
-  "EnabledFolder": "",
+  "EnabledFolder": "customizations//_enabled",
   "Controls": {
     "Damage": [
       {
@@ -36,54 +36,44 @@
         "Label": "Damage Numbers",
         "Type": "ComboBox",
         "Value": "4",
+        "ComboFiles": [
+          "Damage/[Damage Numbers] Big",
+          "Damage/[Damage Numbers] Big Minusless",
+          "Damage/[Damage Numbers] Medium",
+          "Damage/[Damage Numbers] Medium Minusless",
+          "Damage/[Damage Numbers] Small (Default ON)",
+          "Damage/[Damage Numbers] Small Minusless"
+        ],
         "Options": [
           {
             "Label": "Big",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Damage/[Damage Numbers] Big"
           },
           {
             "Label": "Big Minusless",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Damage Numbers] Big Minusless"
           },
           {
             "Label": "Medium",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Damage Numbers] Medium"
           },
           {
             "Label": "Medium Minusless",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Damage Numbers] Medium Minusless"
           },
           {
             "Label": "Small",
             "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Damage Numbers] Small (Default ON)"
           },
           {
             "Label": "Small Minusless",
             "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Damage Numbers] Small Minusless"
           }
         ]
       },
@@ -92,38 +82,32 @@
         "Label": "Last Damage Done",
         "Type": "ComboBox",
         "Value": "3",
+        "ComboFiles": [
+          "Damage/[Last Damage Done] Health Cross",
+          "Damage/[Last Damage Done] Minmode",
+          "Damage/[Last Damage Done] Normal",
+          "Damage/[Last Damage Done] OFF (Default ON)"
+        ],
         "Options": [
           {
             "Label": "Health Cross",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Damage/[Last Damage Done] Health Cross"
           },
           {
             "Label": "Minmode",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Last Damage Done] Minmode"
           },
           {
             "Label": "Normal",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Last Damage Done] Normal"
           },
           {
-            "Label": "Off",
+            "Label": "OFF",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Damage/[Last Damage Done] OFF (Default ON)"
           }
         ]
       },
@@ -132,230 +116,134 @@
         "Label": "Font",
         "Type": "ComboBox",
         "Value": "15",
+        "ComboFiles": [
+          "Fonts/[Font] Alternate Gothic",
+          "Fonts/[Font] Avenir",
+          "Fonts/[Font] Catamaran",
+          "Fonts/[Font] Cerbetica",
+          "Fonts/[Font] Days",
+          "Fonts/[Font] Handel Gothic",
+          "Fonts/[Font] Lato",
+          "Fonts/[Font] Maven Pro",
+          "Fonts/[Font] Neutra",
+          "Fonts/[Font] Noto",
+          "Fonts/[Font] Product",
+          "Fonts/[Font] Product Bold",
+          "Fonts/[Font] Renogare",
+          "Fonts/[Font] Roboto",
+          "Fonts/[Font] Rubik",
+          "Fonts/[Font] Surface (Default ON)",
+          "Fonts/[Font] Surface Bold",
+          "Fonts/[Font] Surface Sharpened",
+          "Fonts/[Font] TF2",
+          "Fonts/[Font] TF2 Bold",
+          "Fonts/[Font] Ubuntu"
+        ],
         "Options": [
           {
             "Label": "Alternate Gothic",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Fonts/[Font] Alternate Gothic"
           },
           {
             "Label": "Avenir",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Avenir"
           },
           {
             "Label": "Catamaran",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Catamaran"
           },
           {
             "Label": "Cerbetica",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Cerbetica"
           },
           {
             "Label": "Days",
             "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Days"
           },
           {
             "Label": "Handel Gothic",
             "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Handel Gothic"
           },
           {
             "Label": "Lato",
             "Value": "6",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Lato"
           },
           {
             "Label": "Maven Pro",
             "Value": "7",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Maven Pro"
           },
           {
             "Label": "Neutra",
             "Value": "8",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Neutra"
           },
           {
             "Label": "Noto",
             "Value": "9",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Noto"
           },
           {
             "Label": "Product",
             "Value": "10",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Product"
           },
           {
             "Label": "Product Bold",
             "Value": "11",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Product Bold"
           },
           {
             "Label": "Renogare",
             "Value": "12",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Renogare"
           },
           {
             "Label": "Roboto",
             "Value": "13",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Roboto"
           },
           {
             "Label": "Rubik",
             "Value": "14",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Rubik"
           },
           {
             "Label": "Surface",
             "Value": "15",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Surface (Default ON)"
           },
           {
             "Label": "Surface Bold",
             "Value": "16",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Surface Bold"
           },
           {
             "Label": "Surface Sharpened",
             "Value": "17",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Surface Sharpened"
           },
           {
             "Label": "TF2",
             "Value": "18",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] TF2"
           },
           {
             "Label": "TF2 Bold",
             "Value": "19",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] TF2 Bold"
           },
           {
             "Label": "Ubuntu",
             "Value": "20",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
-          }
-        ]
-      },
-      {
-        "Name": "mh_damage_numbers",
-        "Label": "Damage Numbers",
-        "Type": "ComboBox",
-        "Value": "4",
-        "Options": [
-          {
-            "Label": "Big",
-            "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
-          },
-          {
-            "Label": "Big Minusless",
-            "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
-          },
-          {
-            "Label": "Medium",
-            "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
-          },
-          {
-            "Label": "Medium Minusless",
-            "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
-          },
-          {
-            "Label": "Small",
-            "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
-          },
-          {
-            "Label": "Small Minusless",
-            "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Fonts/[Font] Ubuntu"
           }
         ]
       },
@@ -364,22 +252,20 @@
         "Label": "Head Counter",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Heads Counter/[Counter] Bottom Right (Default ON)",
+          "Heads Counter/[Counter] Under Ammo"
+        ],
         "Options": [
           {
             "Label": "Bottom Right",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Heads Counter/[Counter] Bottom Right (Default ON)"
           },
           {
             "Label": "Under Ammo",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Heads Counter/[Counter] Under Ammo"
           }
         ]
       },
@@ -388,36 +274,27 @@
         "Label": "Flashing Ammo Colors",
         "Type": "Checkbox",
         "Value": "false",
-        "Files": {
-          "scripts/hudanimations_hitmarker.txt": {
-            "uncomment": [
-              "StopEvent HitMarker",
-              "RunEvent HitMarker"
-            ]
-          }
-        }
+        "FileName": "Health Ammo Uber Animation Style/[Ammo Style] Flashing Colors"
       },
       {
         "Name": "mh_general_style",
         "Label": "General Style",
         "Type": "ComboBox",
         "Value": "1",
+        "ComboFiles": [
+          "Health Ammo Uber Animation Style/[General Style] Colored Number",
+          "Health Ammo Uber Animation Style/[General Style] Colored Shadow (Default ON)"
+        ],
         "Options": [
           {
             "Label": "Colored Nunmber",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[General Style] Colored Number"
           },
           {
             "Label": "Colored Shadow",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[General Style] Colored Shadow (Default ON)"
           }
         ]
       },
@@ -426,70 +303,56 @@
         "Label": "Health Buff",
         "Type": "ComboBox",
         "Value": "2",
+        "ComboFiles": [
+          "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Big Font",
+          "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Small Font",
+          "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Big Font (Default ON)",
+          "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Small Font",
+          "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Big Font",
+          "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Small Font",
+          "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Big Font",
+          "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Small Font"
+        ],
         "Options": [
           {
             "Label": "Buff Rectangle, Big Font",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Big Font"
           },
           {
             "Label": "Buff Rectangle, Small Font",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Animated Buff Rectangle + Small Font"
           },
           {
             "Label": "Buff Cross, Big Font",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Big Font (Default ON)"
           },
           {
             "Label": "Buff Cross, Small Font",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Buff Cross + Small Font"
           },
           {
             "Label": "No Cross, Big Font",
             "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Big Font"
           },
           {
             "Label": "No Cross, Small Font",
             "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] No Buff Cross + Small Font"
           },
           {
             "Label": "Static Rectangle, Big Font",
             "Value": "6",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Big Font"
           },
           {
             "Label": "Static Rectangle, Small Font",
             "Value": "7",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Animation Style/[Health Buff] Static Buff Rectangle + Small Font"
           }
         ]
       },
@@ -498,54 +361,44 @@
         "Label": "Health, Ammo, Uber",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Big Font (Default ON)",
+          "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Small Font",
+          "Health Ammo Uber Style/[Health] Health Cross",
+          "Health Ammo Uber Style/[Health] Health Cross With Team Colored Border",
+          "Health Ammo Uber Style/[Ubercharge] Old m0rehud Style",
+          "Health Ammo Uber Style/[Ubercharge] Uber Meter & Small Label Off"
+        ],
         "Options": [
           {
             "Label": "Default Style, Big Font",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Big Font (Default ON)"
           },
           {
             "Label": "Default Style, Small Font",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Style/[Health - Ammo - Uber] Default Style, Small Font"
           },
           {
             "Label": "Health Cross",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Style/[Health] Health Cross"
           },
           {
             "Label": "Health Cross w/Team Colors",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Style/[Health] Health Cross With Team Colored Border"
           },
           {
             "Label": "Old m0rehud Style",
             "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Style/[Ubercharge] Old m0rehud Style"
           },
           {
             "Label": "Uber Meter & Small Label Off",
             "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Health Ammo Uber Style/[Ubercharge] Uber Meter & Small Label Off"
           }
         ]
       },
@@ -554,68 +407,62 @@
         "Label": "Killstreak",
         "Type": "ComboBox",
         "Value": "2",
+        "ComboFiles": [
+          "Killstreak/[Killstreak] Counter Bottom Left",
+          "Killstreak/[Killstreak] Counter Close To The Killfeed",
+          "Killstreak/[Killstreak] Counter Disabled (Default ON)"
+        ],
         "Options": [
           {
             "Label": "Bottom Left",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Killstreak/[Killstreak] Counter Bottom Left"
           },
           {
             "Label": "Close to Killfeed",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Killstreak/[Killstreak] Counter Close To The Killfeed"
           },
           {
             "Label": "Disabled",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Killstreak/[Killstreak] Counter Disabled (Default ON)"
           }
         ]
       },
-      {
-        "Name": "mh_minmode",
-        "Label": "Toggle Minmode",
-        "Type": "Checkbox",
-        "Value": "false",
-        "Files": {
-          "scripts/hudanimations_hitmarker.txt": {
-            "uncomment": [
-              "StopEvent HitMarker",
-              "RunEvent HitMarker"
-            ]
-          }
-        }
-      },
+      //{
+      //  "Name": "mh_minmode",
+      //  "Label": "Toggle Minmode",
+      //  "Type": "Checkbox",
+      //  "Value": "false",
+      //  "Files": {
+      //    "scripts/hudanimations_hitmarker.txt": {
+      //      "uncomment": [
+      //        "StopEvent HitMarker",
+      //        "RunEvent HitMarker"
+      //      ]
+      //    }
+      //  }
+      //},
       {
         "Name": "mh_scoreboard",
-        "Label": "Killstreak",
+        "Label": "Scoreboard",
         "Type": "ComboBox",
         "Value": "1",
+        "ComboFiles": [
+          "Scoreboards/[Scoreboard] Fosters",
+          "Scoreboards/[Scoreboard] m0re (Default ON)"
+        ],
         "Options": [
           {
             "Label": "Fosters",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Scoreboards/[Scoreboard] Fosters"
           },
           {
             "Label": "m0re",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Scoreboards/[Scoreboard] m0re (Default ON)"
           }
         ]
       },
@@ -624,102 +471,84 @@
         "Label": "Source Scheme",
         "Type": "ComboBox",
         "Value": "3",
+        "ComboFiles": [
+          "SourceSchemes/[SourceScheme] Blue",
+          "SourceSchemes/[SourceScheme] Cyan",
+          "SourceSchemes/[SourceScheme] Fuchsia",
+          "SourceSchemes/[SourceScheme] Green",
+          "SourceSchemes/[SourceScheme] Orange",
+          "SourceSchemes/[SourceScheme] Pink",
+          "SourceSchemes/[SourceScheme] Purple",
+          "SourceSchemes/[SourceScheme] Teal",
+          "SourceSchemes/[SourceScheme] Yellow"
+        ],
         "Options": [
           {
             "Label": "Blue",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Blue"
           },
           {
             "Label": "Cyan",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Cyan"
           },
           {
             "Label": "Fuchsia",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Fuchsia"
           },
           {
             "Label": "Green",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Green"
           },
           {
             "Label": "Orange",
             "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Orange"
           },
           {
             "Label": "Pink",
             "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Pink"
           },
           {
             "Label": "Purple",
             "Value": "6",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Purple"
           },
           {
             "Label": "Teal",
             "Value": "7",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Teal"
           },
           {
             "Label": "Yellow",
             "Value": "8",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "SourceSchemes/[SourceScheme] Yellow"
           }
         ]
       },
       {
-        "Name": "mh_source_scheme",
+        "Name": "mh_spectator",
         "Label": "Spectator",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Spectator/[SpectatorHUD] Leftside and Right Side (Default ON)",
+          "Spectator/[SpectatorHUD] Leftside Only"
+        ],
         "Options": [
           {
             "Label": "Left and Right Side",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Spectator/[SpectatorHUD] Leftside and Right Side (Default ON)"
           },
           {
             "Label": "Left Side Only",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Spectator/[SpectatorHUD] Leftside Only"
           }
         ]
       },
@@ -728,30 +557,26 @@
         "Label": "Speedometer",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Speedometer/[Speed] Speedometer OFF (Default ON)",
+          "Speedometer/[Speed] Speedometer ON - Absolute Speed",
+          "Speedometer/[Speed] Speedometer ON - Horizontal Speed"
+        ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Speedometer/[Speed] Speedometer OFF (Default ON)"
           },
           {
             "Label": "ON - Absolute Speed",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Speedometer/[Speed] Speedometer ON - Absolute Speed"
           },
           {
             "Label": "ON - Horizontal Speed",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Speedometer/[Speed] Speedometer ON - Horizontal Speed"
           }
         ]
       },
@@ -760,22 +585,20 @@
         "Label": "Spy Disguise Image",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Spy Disguise/[Disguise] Spy Disguise Image OFF (Default ON)",
+          "Spy Disguise/[Disguise] Spy Disguise Image ON"
+        ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Spy Disguise/[Disguise] Spy Disguise Image OFF (Default ON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Spy Disguise/[Disguise] Spy Disguise Image ON"
           }
         ]
       },
@@ -784,22 +607,20 @@
         "Label": "TargetId",
         "Type": "ComboBox",
         "Value": "1",
+        "ComboFiles": [
+          "TargetID/[TargetID] Health Cross",
+          "TargetID/[TargetID] Health Numbers (Default ON)"
+        ],
         "Options": [
           {
             "Label": "Health Cross",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "TargetID/[TargetID] Health Cross"
           },
           {
             "Label": "Health Numbers",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "TargetID/[TargetID] Health Numbers (Default ON)"
           }
         ]
       },
@@ -808,78 +629,68 @@
         "Label": "Themes",
         "Type": "ComboBox",
         "Value": "3",
+        "ComboFiles": [
+          "Themes/[Theme] Blue",
+          "Themes/[Theme] Cyan",
+          "Themes/[Theme] Green",
+          "Themes/[Theme] Green & Fuchsia (Default ON)",
+          "Themes/[Theme] Orange",
+          "Themes/[Theme] Pink",
+          "Themes/[Theme] Purple",
+          "Themes/[Theme] Teal",
+          "Themes/[Theme] White",
+          "Themes/[Theme] Yellow"
+        ],
         "Options": [
           {
             "Label": "Blue",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Themes/[Theme] Blue"
           },
           {
             "Label": "Cyan",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Cyan"
           },
           {
             "Label": "Green",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Green"
           },
           {
             "Label": "Green & Fuchsia",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Green & Fuchsia (Default ON)"
           },
           {
             "Label": "Orange",
             "Value": "4",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Orange"
           },
           {
             "Label": "Pink",
             "Value": "5",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Pink"
           },
           {
             "Label": "Purple",
             "Value": "6",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Purple"
           },
           {
             "Label": "Teal",
             "Value": "7",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Themes/[Theme] Teal"
+          },
+          {
+            "Label": "White",
+            "Value": "8",
+            "FileName": "Themes/[Theme] White"
           },
           {
             "Label": "Yellow",
-            "Value": "8",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "Value": "9",
+            "FileName": "Themes/[Theme] Yellow"
           }
         ]
       },
@@ -888,38 +699,32 @@
         "Label": "Match Status",
         "Type": "ComboBox",
         "Value": "2",
+        "ComboFiles": [
+          "Timers & Match Status/[MatchStatus] HealthBar Big",
+          "Timers & Match Status/[MatchStatus] HealthBar Small",
+          "Timers & Match Status/[MatchStatus] HealthBar Static (DefaultON)",
+          "Timers & Match Status/[MatchStatus] Names ON"
+        ],
         "Options": [
           {
             "Label": "Health Bar Big",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Timers & Match Status/[MatchStatus] HealthBar Big"
           },
           {
             "Label": "Health Bar Small",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Timers & Match Status/[MatchStatus] HealthBar Small"
           },
           {
             "Label": "Health Bar Static",
             "Value": "2",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Timers & Match Status/[MatchStatus] HealthBar Static (DefaultON)"
           },
           {
             "Label": "Names ON",
             "Value": "3",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Timers & Match Status/[MatchStatus] Names ON"
           }
         ]
       },
@@ -928,22 +733,20 @@
         "Label": "Timer Background",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Timers & Match Status/[Timer] Background OFF (DefaultON)",
+          "Timers & Match Status/[Timer] Background ON"
+        ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Timers & Match Status/[Timer] Background OFF (DefaultON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Timers & Match Status/[Timer] Background ON"
           }
         ]
       },
@@ -952,22 +755,20 @@
         "Label": "Transparent Viewmodels",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels OFF (Default ON)",
+          "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels ON"
+        ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels OFF (Default ON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Transparent Viewmodels/[Viewmodel] Transparent Viewmodels ON"
           }
         ]
       },
@@ -976,22 +777,20 @@
         "Label": "Uber Counters",
         "Type": "ComboBox",
         "Value": "0",
+        "ComboFiles": [
+          "Uber Counter/[Counter] Uber Counter OFF (Default ON)",
+          "Uber Counter/[Counter] Uber Counter ON"
+        ],
         "Options": [
           {
             "Label": "OFF",
             "Value": "0",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_4x3/",
-              "NewName": "^customizations/#resolutions/4x3/"
-            }
+            "FileName": "Uber Counter/[Counter] Uber Counter OFF (Default ON)"
           },
           {
             "Label": "ON",
             "Value": "1",
-            "RenameFile": {
-              "OldName": "^customizations/#resolutions/_16x9/",
-              "NewName": "^customizations/#resolutions/16x9/"
-            }
+            "FileName": "Uber Counter/[Counter] Uber Counter ON"
           }
         ]
       }

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -37,7 +37,7 @@
         "Label": "Font",
         "Type": "ComboBox",
         "Value": "15",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Fonts\\[Font] Alternate Gothic",
           "Fonts\\[Font] Avenir",
           "Fonts\\[Font] Catamaran",
@@ -173,7 +173,7 @@
         "Label": "Head Counter",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Heads Counter\\[Counter] Bottom Right (Default ON)",
           "Heads Counter\\[Counter] Under Ammo"
         ],
@@ -210,7 +210,7 @@
         "Label": "Scoreboard",
         "Type": "ComboBox",
         "Value": "1",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Scoreboards\\[Scoreboard] Fosters",
           "Scoreboards\\[Scoreboard] m0re (Default ON)"
         ],
@@ -232,7 +232,7 @@
         "Label": "Source Scheme",
         "Type": "ComboBox",
         "Value": "3",
-        "ComboFiles": [
+        "ComboDirectories": [
           "SourceSchemes\\[SourceScheme] Blue",
           "SourceSchemes\\[SourceScheme] Cyan",
           "SourceSchemes\\[SourceScheme] Fuchsia",
@@ -296,7 +296,7 @@
         "Label": "Spectator",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Spectator\\[SpectatorHUD] Leftside and Right Side (Default ON)",
           "Spectator\\[SpectatorHUD] Leftside Only"
         ],
@@ -318,7 +318,7 @@
         "Label": "Speedometer",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Speedometer\\[Speed] Speedometer OFF (Default ON)",
           "Speedometer\\[Speed] Speedometer ON - Absolute Speed",
           "Speedometer\\[Speed] Speedometer ON - Horizontal Speed"
@@ -346,7 +346,7 @@
         "Label": "Spy Disguise Image",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Spy Disguise\\[Disguise] Spy Disguise Image OFF (Default ON)",
           "Spy Disguise\\[Disguise] Spy Disguise Image ON"
         ],
@@ -368,7 +368,7 @@
         "Label": "TargetId",
         "Type": "ComboBox",
         "Value": "1",
-        "ComboFiles": [
+        "ComboDirectories": [
           "TargetID\\[TargetID] Health Cross",
           "TargetID\\[TargetID] Health Numbers (Default ON)"
         ],
@@ -390,7 +390,7 @@
         "Label": "Themes",
         "Type": "ComboBox",
         "Value": "3",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Themes\\[Theme] Blue",
           "Themes\\[Theme] Cyan",
           "Themes\\[Theme] Green",
@@ -460,7 +460,7 @@
         "Label": "Match Status",
         "Type": "ComboBox",
         "Value": "2",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Timers & Match Status\\[MatchStatus] HealthBar Big",
           "Timers & Match Status\\[MatchStatus] HealthBar Small",
           "Timers & Match Status\\[MatchStatus] HealthBar Static (DefaultON)",
@@ -494,7 +494,7 @@
         "Label": "Timer Background",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Timers & Match Status\\[Timer] Background OFF (DefaultON)",
           "Timers & Match Status\\[Timer] Background ON"
         ],
@@ -516,7 +516,7 @@
         "Label": "Transparent Viewmodels",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels OFF (Default ON)",
           "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels ON"
         ],
@@ -684,7 +684,7 @@
         "Label": "Health Buff",
         "Type": "ComboBox",
         "Value": "2",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font",
           "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font",
           "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)",
@@ -840,7 +840,7 @@
         "Label": "General Style",
         "Type": "ComboBox",
         "Value": "1",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Health Ammo Uber Animation Style\\[General Style] Colored Number",
           "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
         ],
@@ -862,7 +862,7 @@
         "Label": "Health, Ammo, Uber",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)",
           "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font",
           "Health Ammo Uber Style\\[Health] Health Cross",
@@ -908,7 +908,7 @@
         "Label": "Killstreak",
         "Type": "ComboBox",
         "Value": "2",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Killstreak\\[Killstreak] Counter Bottom Left",
           "Killstreak\\[Killstreak] Counter Close To The Killfeed",
           "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
@@ -977,7 +977,7 @@
         "Label": "Uber Counters",
         "Type": "ComboBox",
         "Value": "0",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Uber Counter\\[Counter] Uber Counter OFF (Default ON)",
           "Uber Counter\\[Counter] Uber Counter ON"
         ],
@@ -1096,7 +1096,7 @@
         "Label": "Damage Numbers",
         "Type": "ComboBox",
         "Value": "4",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Damage\\[Damage Numbers] Big",
           "Damage\\[Damage Numbers] Big Minusless",
           "Damage\\[Damage Numbers] Medium",
@@ -1142,7 +1142,7 @@
         "Label": "Last Damage Done",
         "Type": "ComboBox",
         "Value": "3",
-        "ComboFiles": [
+        "ComboDirectories": [
           "Damage\\[Last Damage Done] Health Cross",
           "Damage\\[Last Damage Done] Minmode",
           "Damage\\[Last Damage Done] Normal",

--- a/src/TF2HUD.Editor/JSON/m0rehud.json
+++ b/src/TF2HUD.Editor/JSON/m0rehud.json
@@ -11,9 +11,10 @@
   ],
   "Background": "https://i.imgur.com/cBFURIz.png",
   "Layout": [
-    "0 0 0 0",
-    "0 0 0 0",
-    "0 0 0 0"
+    "0 0 1 1",
+    "6 6 1 1",
+    "4 4 2 2",
+    "5 3 2 2"
   ],
   "Links": {
     "Update": "https://github.com/Hypnootize/m0rehud/archive/refs/heads/master.zip", // TODO: Remove
@@ -30,87 +31,7 @@
   "CustomizationsFolder": "customizations",
   "EnabledFolder": "",
   "Controls": {
-    "Damage": [
-      {
-        "Name": "mh_damage_numbers",
-        "Label": "Damage Numbers",
-        "Type": "ComboBox",
-        "Value": "4",
-        "ComboFiles": [
-          "Damage\\[Damage Numbers] Big",
-          "Damage\\[Damage Numbers] Big Minusless",
-          "Damage\\[Damage Numbers] Medium",
-          "Damage\\[Damage Numbers] Medium Minusless",
-          "Damage\\[Damage Numbers] Small (Default ON)",
-          "Damage\\[Damage Numbers] Small Minusless"
-        ],
-        "Options": [
-          {
-            "Label": "Big",
-            "Value": "0",
-            "FileName": "Damage\\[Damage Numbers] Big"
-          },
-          {
-            "Label": "Big Minusless",
-            "Value": "1",
-            "FileName": "Damage\\[Damage Numbers] Big Minusless"
-          },
-          {
-            "Label": "Medium",
-            "Value": "2",
-            "FileName": "Damage\\[Damage Numbers] Medium"
-          },
-          {
-            "Label": "Medium Minusless",
-            "Value": "3",
-            "FileName": "Damage\\[Damage Numbers] Medium Minusless"
-          },
-          {
-            "Label": "Small",
-            "Value": "4",
-            "FileName": "Damage\\[Damage Numbers] Small (Default ON)"
-          },
-          {
-            "Label": "Small Minusless",
-            "Value": "5",
-            "FileName": "Damage\\[Damage Numbers] Small Minusless"
-          }
-        ]
-      },
-      {
-        "Name": "mh_damage_done",
-        "Label": "Last Damage Done",
-        "Type": "ComboBox",
-        "Value": "3",
-        "ComboFiles": [
-          "Damage\\[Last Damage Done] Health Cross",
-          "Damage\\[Last Damage Done] Minmode",
-          "Damage\\[Last Damage Done] Normal",
-          "Damage\\[Last Damage Done] OFF (Default ON)"
-        ],
-        "Options": [
-          {
-            "Label": "Health Cross",
-            "Value": "0",
-            "FileName": "Damage\\[Last Damage Done] Health Cross"
-          },
-          {
-            "Label": "Minmode",
-            "Value": "1",
-            "FileName": "Damage\\[Last Damage Done] Minmode"
-          },
-          {
-            "Label": "Normal",
-            "Value": "2",
-            "FileName": "Damage\\[Last Damage Done] Normal"
-          },
-          {
-            "Label": "OFF",
-            "Value": "3",
-            "FileName": "Damage\\[Last Damage Done] OFF (Default ON)"
-          }
-        ]
-      },
+    "Customizations": [
       {
         "Name": "mh_font",
         "Label": "Font",
@@ -269,167 +190,7 @@
           }
         ]
       },
-      {
-        "Name": "mh_ammo_style",
-        "Label": "Flashing Ammo Colors",
-        "Type": "Checkbox",
-        "Value": "false",
-        "FileName": "Health Ammo Uber Animation Style\\[Ammo Style] Flashing Colors"
-      },
-      {
-        "Name": "mh_general_style",
-        "Label": "General Style",
-        "Type": "ComboBox",
-        "Value": "1",
-        "ComboFiles": [
-          "Health Ammo Uber Animation Style\\[General Style] Colored Number",
-          "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
-        ],
-        "Options": [
-          {
-            "Label": "Colored Nunmber",
-            "Value": "0",
-            "FileName": "Health Ammo Uber Animation Style\\[General Style] Colored Number"
-          },
-          {
-            "Label": "Colored Shadow",
-            "Value": "1",
-            "FileName": "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
-          }
-        ]
-      },
-      {
-        "Name": "mh_health_buff",
-        "Label": "Health Buff",
-        "Type": "ComboBox",
-        "Value": "2",
-        "ComboFiles": [
-          "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font",
-          "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font",
-          "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)",
-          "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Small Font",
-          "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Big Font",
-          "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Small Font",
-          "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Big Font",
-          "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Small Font"
-        ],
-        "Options": [
-          {
-            "Label": "Buff Rectangle, Big Font",
-            "Value": "0",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font"
-          },
-          {
-            "Label": "Buff Rectangle, Small Font",
-            "Value": "1",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font"
-          },
-          {
-            "Label": "Buff Cross, Big Font",
-            "Value": "2",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)"
-          },
-          {
-            "Label": "Buff Cross, Small Font",
-            "Value": "3",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Small Font"
-          },
-          {
-            "Label": "No Cross, Big Font",
-            "Value": "4",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Big Font"
-          },
-          {
-            "Label": "No Cross, Small Font",
-            "Value": "5",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Small Font"
-          },
-          {
-            "Label": "Static Rectangle, Big Font",
-            "Value": "6",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Big Font"
-          },
-          {
-            "Label": "Static Rectangle, Small Font",
-            "Value": "7",
-            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Small Font"
-          }
-        ]
-      },
-      {
-        "Name": "mh_ammo_uber_style",
-        "Label": "Health, Ammo, Uber",
-        "Type": "ComboBox",
-        "Value": "0",
-        "ComboFiles": [
-          "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)",
-          "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font",
-          "Health Ammo Uber Style\\[Health] Health Cross",
-          "Health Ammo Uber Style\\[Health] Health Cross With Team Colored Border",
-          "Health Ammo Uber Style\\[Ubercharge] Old m0rehud Style",
-          "Health Ammo Uber Style\\[Ubercharge] Uber Meter & Small Label Off"
-        ],
-        "Options": [
-          {
-            "Label": "Default Style, Big Font",
-            "Value": "0",
-            "FileName": "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)"
-          },
-          {
-            "Label": "Default Style, Small Font",
-            "Value": "1",
-            "FileName": "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font"
-          },
-          {
-            "Label": "Health Cross",
-            "Value": "2",
-            "FileName": "Health Ammo Uber Style\\[Health] Health Cross"
-          },
-          {
-            "Label": "Health Cross w/Team Colors",
-            "Value": "3",
-            "FileName": "Health Ammo Uber Style\\[Health] Health Cross With Team Colored Border"
-          },
-          {
-            "Label": "Old m0rehud Style",
-            "Value": "4",
-            "FileName": "Health Ammo Uber Style\\[Ubercharge] Old m0rehud Style"
-          },
-          {
-            "Label": "Uber Meter & Small Label Off",
-            "Value": "5",
-            "FileName": "Health Ammo Uber Style\\[Ubercharge] Uber Meter & Small Label Off"
-          }
-        ]
-      },
-      {
-        "Name": "mh_ammo_uber_style",
-        "Label": "Killstreak",
-        "Type": "ComboBox",
-        "Value": "2",
-        "ComboFiles": [
-          "Killstreak\\[Killstreak] Counter Bottom Left",
-          "Killstreak\\[Killstreak] Counter Close To The Killfeed",
-          "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
-        ],
-        "Options": [
-          {
-            "Label": "Bottom Left",
-            "Value": "0",
-            "FileName": "Killstreak\\[Killstreak] Counter Bottom Left"
-          },
-          {
-            "Label": "Close to Killfeed",
-            "Value": "1",
-            "FileName": "Killstreak\\[Killstreak] Counter Close To The Killfeed"
-          },
-          {
-            "Label": "Disabled",
-            "Value": "2",
-            "FileName": "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
-          }
-        ]
-      },
+
       //{
       //  "Name": "mh_minmode",
       //  "Label": "Toggle Minmode",
@@ -771,6 +532,445 @@
             "FileName": "Transparent Viewmodels\\[Viewmodel] Transparent Viewmodels ON"
           }
         ]
+      }
+    ],
+    "Health": [
+      {
+        "Name": "mh_health_numbers",
+        "Label": "Health Numbers",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Numbers": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_buff",
+        "Label": "Health Buff",
+        "Type": "ColorPicker",
+        "Value": "0 185 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Buff": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_buff_target",
+        "Label": "Health Buff Target",
+        "Type": "ColorPicker",
+        "Value": "0 215 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Buff Target": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_buff_spec",
+        "Label": "Health Buff Spec",
+        "Type": "ColorPicker",
+        "Value": "0 215 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Buff Spec": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_buff_killer",
+        "Label": "Health Buff Killer",
+        "Type": "ColorPicker",
+        "Value": "0 215 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Buff Killer": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_hurt",
+        "Label": "Health Hurt",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Hurt": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_hurt_target",
+        "Label": "Health Hurt Target",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Hurt Target": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_hurt_spec",
+        "Label": "Health Hurt Spec",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Hurt Spec": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_hurt_killer",
+        "Label": "Health Hurt Killer",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Health Hurt Killer": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_health_buff",
+        "Label": "Health Buff",
+        "Type": "ComboBox",
+        "Value": "2",
+        "ComboFiles": [
+          "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)",
+          "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Small Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Big Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Small Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Big Font",
+          "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Small Font"
+        ],
+        "Options": [
+          {
+            "Label": "Buff Rectangle, Big Font",
+            "Value": "0",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Big Font"
+          },
+          {
+            "Label": "Buff Rectangle, Small Font",
+            "Value": "1",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Animated Buff Rectangle + Small Font"
+          },
+          {
+            "Label": "Buff Cross, Big Font",
+            "Value": "2",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Big Font (Default ON)"
+          },
+          {
+            "Label": "Buff Cross, Small Font",
+            "Value": "3",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Buff Cross + Small Font"
+          },
+          {
+            "Label": "No Cross, Big Font",
+            "Value": "4",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Big Font"
+          },
+          {
+            "Label": "No Cross, Small Font",
+            "Value": "5",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] No Buff Cross + Small Font"
+          },
+          {
+            "Label": "Static Rectangle, Big Font",
+            "Value": "6",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Big Font"
+          },
+          {
+            "Label": "Static Rectangle, Small Font",
+            "Value": "7",
+            "FileName": "Health Ammo Uber Animation Style\\[Health Buff] Static Buff Rectangle + Small Font"
+          }
+        ]
+      }
+    ],
+    "Ammo": [
+      {
+        "Name": "mh_ammo_in_clip",
+        "Label": "Ammo In Clip",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ammo In Clip": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_ammo_in_reserve",
+        "Label": "Ammo In Reserve",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ammo In Reserve": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_ammo_no_clip",
+        "Label": "Ammo No Clip",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ammo No Clip": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_ammo_in_clip_low",
+        "Label": "Ammo In Clip Low",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ammo In Clip Low": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_ammo_in_reserve_low",
+        "Label": "Ammo In Reserve Low",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ammo In Reserve Low": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_ammo_no_clip_low",
+        "Label": "Ammo No Clip Low",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ammo No Clip Low": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_general_style",
+        "Label": "General Style",
+        "Type": "ComboBox",
+        "Value": "1",
+        "ComboFiles": [
+          "Health Ammo Uber Animation Style\\[General Style] Colored Number",
+          "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
+        ],
+        "Options": [
+          {
+            "Label": "Colored Number",
+            "Value": "0",
+            "FileName": "Health Ammo Uber Animation Style\\[General Style] Colored Number"
+          },
+          {
+            "Label": "Colored Shadow",
+            "Value": "1",
+            "FileName": "Health Ammo Uber Animation Style\\[General Style] Colored Shadow (Default ON)"
+          }
+        ]
+      },
+      {
+        "Name": "mh_ammo_uber_style",
+        "Label": "Health, Ammo, Uber",
+        "Type": "ComboBox",
+        "Value": "0",
+        "ComboFiles": [
+          "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)",
+          "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font",
+          "Health Ammo Uber Style\\[Health] Health Cross",
+          "Health Ammo Uber Style\\[Health] Health Cross With Team Colored Border",
+          "Health Ammo Uber Style\\[Ubercharge] Old m0rehud Style",
+          "Health Ammo Uber Style\\[Ubercharge] Uber Meter & Small Label Off"
+        ],
+        "Options": [
+          {
+            "Label": "Default Style, Big Font",
+            "Value": "0",
+            "FileName": "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Big Font (Default ON)"
+          },
+          {
+            "Label": "Default Style, Small Font",
+            "Value": "1",
+            "FileName": "Health Ammo Uber Style\\[Health - Ammo - Uber] Default Style, Small Font"
+          },
+          {
+            "Label": "Health Cross",
+            "Value": "2",
+            "FileName": "Health Ammo Uber Style\\[Health] Health Cross"
+          },
+          {
+            "Label": "Health Cross w/Team Colors",
+            "Value": "3",
+            "FileName": "Health Ammo Uber Style\\[Health] Health Cross With Team Colored Border"
+          },
+          {
+            "Label": "Old m0rehud Style",
+            "Value": "4",
+            "FileName": "Health Ammo Uber Style\\[Ubercharge] Old m0rehud Style"
+          },
+          {
+            "Label": "Uber Meter & Small Label Off",
+            "Value": "5",
+            "FileName": "Health Ammo Uber Style\\[Ubercharge] Uber Meter & Small Label Off"
+          }
+        ]
+      },
+      {
+        "Name": "mh_ammo_uber_style",
+        "Label": "Killstreak",
+        "Type": "ComboBox",
+        "Value": "2",
+        "ComboFiles": [
+          "Killstreak\\[Killstreak] Counter Bottom Left",
+          "Killstreak\\[Killstreak] Counter Close To The Killfeed",
+          "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
+        ],
+        "Options": [
+          {
+            "Label": "Bottom Left",
+            "Value": "0",
+            "FileName": "Killstreak\\[Killstreak] Counter Bottom Left"
+          },
+          {
+            "Label": "Close to Killfeed",
+            "Value": "1",
+            "FileName": "Killstreak\\[Killstreak] Counter Close To The Killfeed"
+          },
+          {
+            "Label": "Disabled",
+            "Value": "2",
+            "FileName": "Killstreak\\[Killstreak] Counter Disabled (Default ON)"
+          }
+        ]
+      },
+      {
+        "Name": "mh_ammo_style",
+        "Label": "Flashing Ammo Colors",
+        "Type": "Checkbox",
+        "Value": "false",
+        "FileName": "Health Ammo Uber Animation Style\\[Ammo Style] Flashing Colors"
+      }
+    ],
+    "Ubercharge": [
+      {
+        "Name": "mh_ubercharge",
+        "Label": "Ubercharge",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ubercharge": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_ubercharge_full",
+        "Label": "Ubercharge Full",
+        "Type": "ColorPicker",
+        "Value": "255 0 127 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Ubercharge Full": "$value"
+              }
+            }
+          }
+        }
       },
       {
         "Name": "mh_uber_counters",
@@ -793,6 +993,265 @@
             "FileName": "Uber Counter\\[Counter] Uber Counter ON"
           }
         ]
+      }
+    ],
+    "Crosshair": [
+      {
+        "Name": "mh_crosshair",
+        "Label": "Crosshair",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Crosshair": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_crosshair_flash",
+        "Label": "Crosshair Flash",
+        "Type": "ColorPicker",
+        "Value": "255 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Crosshair Flash": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_crosshair_style",
+        "Label": "Style",
+        "Type": "Crosshair",
+        "Value": "?",
+        "Files": {
+          "scripts/crosshairs/crosshairs.res": {
+            "CustomCrosshair": {
+              "labelText": "$value"
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_crosshair_toggle",
+        "Label": "Toggle",
+        "Type": "Checkbox",
+        "Value": "false",
+        "Files": {
+          "scripts/crosshairs/crosshairs.res": {
+            "CustomCrosshair": {
+              "visible": {
+                "true": "1",
+                "false": "0"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "Damage": [
+      {
+        "Name": "mh_heal_numbers",
+        "Label": "Heal Numbers",
+        "Type": "ColorPicker",
+        "Value": "0 255 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Heal Numbers": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_last_damage_done",
+        "Label": "Last Damage Done",
+        "Type": "ColorPicker",
+        "Value": "255 255 255 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Last Damage Done": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_damage_numbers",
+        "Label": "Damage Numbers",
+        "Type": "ComboBox",
+        "Value": "4",
+        "ComboFiles": [
+          "Damage\\[Damage Numbers] Big",
+          "Damage\\[Damage Numbers] Big Minusless",
+          "Damage\\[Damage Numbers] Medium",
+          "Damage\\[Damage Numbers] Medium Minusless",
+          "Damage\\[Damage Numbers] Small (Default ON)",
+          "Damage\\[Damage Numbers] Small Minusless"
+        ],
+        "Options": [
+          {
+            "Label": "Big",
+            "Value": "0",
+            "FileName": "Damage\\[Damage Numbers] Big"
+          },
+          {
+            "Label": "Big Minusless",
+            "Value": "1",
+            "FileName": "Damage\\[Damage Numbers] Big Minusless"
+          },
+          {
+            "Label": "Medium",
+            "Value": "2",
+            "FileName": "Damage\\[Damage Numbers] Medium"
+          },
+          {
+            "Label": "Medium Minusless",
+            "Value": "3",
+            "FileName": "Damage\\[Damage Numbers] Medium Minusless"
+          },
+          {
+            "Label": "Small",
+            "Value": "4",
+            "FileName": "Damage\\[Damage Numbers] Small (Default ON)"
+          },
+          {
+            "Label": "Small Minusless",
+            "Value": "5",
+            "FileName": "Damage\\[Damage Numbers] Small Minusless"
+          }
+        ]
+      },
+      {
+        "Name": "mh_damage_done",
+        "Label": "Last Damage Done",
+        "Type": "ComboBox",
+        "Value": "3",
+        "ComboFiles": [
+          "Damage\\[Last Damage Done] Health Cross",
+          "Damage\\[Last Damage Done] Minmode",
+          "Damage\\[Last Damage Done] Normal",
+          "Damage\\[Last Damage Done] OFF (Default ON)"
+        ],
+        "Options": [
+          {
+            "Label": "Health Cross",
+            "Value": "0",
+            "FileName": "Damage\\[Last Damage Done] Health Cross"
+          },
+          {
+            "Label": "Minmode",
+            "Value": "1",
+            "FileName": "Damage\\[Last Damage Done] Minmode"
+          },
+          {
+            "Label": "Normal",
+            "Value": "2",
+            "FileName": "Damage\\[Last Damage Done] Normal"
+          },
+          {
+            "Label": "OFF",
+            "Value": "3",
+            "FileName": "Damage\\[Last Damage Done] OFF (Default ON)"
+          }
+        ]
+      }
+    ],
+    "Colors": [
+      {
+        "Name": "mh_extra_shadow",
+        "Label": "Extra Shadow",
+        "Type": "ColorPicker",
+        "Value": "0 0 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Extra Shadow": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_menu_labels",
+        "Label": "Menu Labels",
+        "Type": "ColorPicker",
+        "Value": "255 0 127 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Menu Labels": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_class_selection",
+        "Label": "Class Selection",
+        "Type": "ColorPicker",
+        "Value": "0 215 0 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "Class Selection": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_m0reBlue",
+        "Label": "m0reBlue",
+        "Type": "ColorPicker",
+        "Value": "0 120 201 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "m0reBlue": "$value"
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "mh_m0reRed",
+        "Label": "m0reRed",
+        "Type": "ColorPicker",
+        "Value": "235 58 58 255",
+        "Restart": true,
+        "Files": {
+          "resource/scheme/colors_scheme.res": {
+            "Scheme": {
+              "Colors": {
+                "m0reRed": "$value"
+              }
+            }
+          }
+        }
       }
     ]
   }

--- a/src/TF2HUD.Editor/JSON/rayshud.json
+++ b/src/TF2HUD.Editor/JSON/rayshud.json
@@ -16,7 +16,6 @@
     "5 5 4 4 6 6"
   ],
   "Links": {
-    "Update": "https://github.com/raysfire/rayshud/archive/master.zip", // TODO: Remove
     "GitHub": "https://github.com/raysfire/rayshud",
     "TF2Huds": "https://tf2huds.dev/hud/rayshud",
     "ComfigHuds": "https://comfig.app/huds/page/rayshud/",

--- a/src/TF2HUD.Editor/JSON/sunsethud.json
+++ b/src/TF2HUD.Editor/JSON/sunsethud.json
@@ -17,7 +17,6 @@
     "0 4 4"
   ],
   "Links": {
-    "Update": "https://github.com/Hypnootize/sunsethud/archive/refs/heads/master.zip", // TODO: Remove
     "GitHub": "https://github.com/Hypnootize/sunsethud",
     "TF2Huds": "https://tf2huds.dev/hud/Sunset-Hud",
     "ComfigHuds": "https://comfig.app/huds/page/sunsethud/",

--- a/src/TF2HUD.Editor/JSON/zeeshud.json
+++ b/src/TF2HUD.Editor/JSON/zeeshud.json
@@ -16,7 +16,6 @@
     "6 6 3 3 1 1"
   ],
   "Links": {
-    "Update": "https://github.com/Zeesastrous/ZeesHUD/archive/refs/heads/main.zip", // TODO: Remove
     "GitHub": "https://github.com/Zeesastrous/ZeesHUD",
     "TF2Huds": "https://tf2huds.dev/hud/ZeesHUD",
     "ComfigHuds": "https://comfig.app/huds/page/zeeshud/",

--- a/src/TF2HUD.Editor/Models/HudJson.cs
+++ b/src/TF2HUD.Editor/Models/HudJson.cs
@@ -36,6 +36,7 @@ namespace HUDEditor.Models
     public class Controls
     {
         [JsonPropertyName("ComboFiles")] public string[] ComboFiles;
+        [JsonPropertyName("ComboDirectories")] public string[] ComboDirectories;
         public UIElement Control;
         [JsonPropertyName("FileName")] public string FileName;
         [JsonPropertyName("Files")] public JObject Files;

--- a/src/TF2HUD.Editor/Views/AppInfoView.xaml
+++ b/src/TF2HUD.Editor/Views/AppInfoView.xaml
@@ -19,13 +19,15 @@
             <Run Text="linked below." />
         </TextBlock>
         <Border Background="#A49E9E" HorizontalAlignment="Stretch" Height="1" Margin="0,15,0,10" />
-        <Label Content="Version 3.1" Style="{StaticResource HeaderText}" Margin="0,0,0,10" />
+        <Label Content="Version 3.2" Style="{StaticResource HeaderText}" Margin="0,0,0,10" />
         <TextBlock Style="{StaticResource BodyText}" FontSize="22" TextAlignment="Left">
-            <Run Text="* Added Italian translations and missing Spanish text." /><LineBreak />
-            <Run Text="* Fixed updates being suggested when on the latest app version." /><LineBreak />
-            <Run Text="* Fixed 'The file scheme is not supported.' error." /><LineBreak />
-            <Run Text="* Fixed the editor incorrectly processing OS tags." /><LineBreak />
-            <Run Text="* Updated documentation. Corrected outdated links." />
+            <Run Text="* Added m0rehud customizations." /><LineBreak />
+            <Run Text="* Added Simplified Chinese translations. (Thanks HotoCocoaco)" /><LineBreak />
+            <Run Text="* Added the Zenith user setting for budhud. (Thanks KaineWooten)" /><LineBreak />
+            <Run Text="* Fixed the install button staying disabled. (Thanks cooolbros)" /><LineBreak />
+            <Run Text="* Updated how the editor checks for new version releases." /><LineBreak />
+            <Run Text="* Updated the editor to be able to copy multiple subfolders." /><LineBreak />
+            <Run Text="* Updated Russian translations. (Thanks Blueberryy)" />
             <LineBreak />
         </TextBlock>
     </StackPanel>


### PR DESCRIPTION
Remaining changes for the 3.2 release, including....
- Added full m0rehud customizations.
- Enabling the editor to copy multiple subfolders for a single customization (this was specifically implemented for m0rehud).
- Removed the now deprecated `Update` tags from HUD schemas.
- Updated the flawhud schema to match latest version.
- Bumping the version number to 3.2