### PR TITLE
Fixed tooltip text

### DIFF
--- a/src/TF2HUD.Editor/JSON/flawhud.json
+++ b/src/TF2HUD.Editor/JSON/flawhud.json
@@ -805,7 +805,7 @@
         "Name": "fh_centered_vacc_icon",
         "Label": "Center Vaccinator Icon",
         "Type": "Checkbox",
-        "ToolTip": "Toggle Mann vs. Machine currency position.",
+        "ToolTip": "Position Vaccinator icon towards the center.",
         "Value": "false",
         "Files": {
           "resource/ui/hudmannvsmachinestatus.res": {


### PR DESCRIPTION
Corrects copied text on the "Center Vaccinator Icon" option.